### PR TITLE
Add `foot --server` to startup_cmds

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -72,6 +72,7 @@ pub const working_directory: union(enum) {
 
 pub const startup_cmds = [_][]const []const u8 {
     &[_][]const u8 { "sh", "-c", "$HOME/.local/bin/swaybgd" },
+    &[_][]const u8{ "foot", "--server" },
 };
 
 pub const xcursor_theme: ?XcursorTheme = null;


### PR DESCRIPTION
As Super+Shift+Return spawns footclient it would be easier for newcomer to spawn terminal on fresh install

Here are keybinginds that are currently in the master
```
        .{
            .keysym = Keysym.Return,
            .modifiers = Super|Shift,
            .action = .{ .spawn = .{ .argv = &[_][]const u8 { "footclient" } } },
        },
        .{
            .keysym = Keysym.e,
            .modifiers = Super,
            .action = .{ .spawn = .{ .argv = &[_][]const u8 { "footclient", "lf" } } },
        },
```

I think it will be useful for someone like me that blindly jumps into the WM with "default config"

The solution is either adding foot server to startup_cmds or make Super+Shift+Return binding to spawn `foot` instead of `footclient` 