### PR TITLE
Fix(bar): box on non-occupied tags with sticky

### DIFF
--- a/src/kwm/bar.zig
+++ b/src/kwm/bar.zig
@@ -376,10 +376,6 @@ fn render_static_component(self: *Self) void {
         var it = context.windows.safeIterator(.forward);
         while (it.next()) |window| {
             if (window.output == self.output) {
-                if (window.sticky) {
-                    windows_tag = @as(u32, @intCast(0)) -% 1;
-                    break;
-                }
                 windows_tag |= window.tag;
             }
         }


### PR DESCRIPTION
Thanks for the sticky indicator!

This fixes an issue where boxes are drawn to all tags if sticky window exists, introduced in commit ed56af70f96de38f5e6937c14ea92db5cd754c40.