### PR TITLE
config.def.zig: keybind Esc to back default mode.

### DIFF
--- a/config.def.zig
+++ b/config.def.zig
@@ -343,6 +343,12 @@ pub const xkb_bindings = blk: {
             .modifiers = Super|Shift,
             .action = .{ .switch_mode = .{ .mode = .default } }
         },
+        .{
+            .mode = .passthrough,
+            .keysym = Keysym.Escape,
+            .modifiers = 0,
+            .action = .{ .switch_mode = .{ .mode = .default } }
+        },
 
 
         // floating
@@ -355,6 +361,12 @@ pub const xkb_bindings = blk: {
             .mode = .floating,
             .keysym = Keysym.f,
             .modifiers = Super|Ctrl,
+            .action = .{ .switch_mode = .{ .mode = .default } },
+        },
+        .{
+            .mode = .floating,
+            .keysym = Keysym.Escape,
+            .modifiers = 0,
             .action = .{ .switch_mode = .{ .mode = .default } },
         },
         .{


### PR DESCRIPTION


Adding keybind `Esc`.

We can easily use `Esc` to back  `default mode`, after entering `floating mode` or `passthrough mode`,


## See Also

* [default keybind](https://github.com/samwhelp/river-kwm-quick-start/blob/main/docs/default/keybind.md#mode)
* [my keybind](https://github.com/samwhelp/river-kwm-quick-start/blob/main/docs/main/keybind.md#mode)
