### PR TITLE
Fix: floating window not vertically centered

### DIFF
--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -682,7 +682,7 @@ fn set_title(self: *Self, title: ?[]const u8) void {
 
 fn center(self: *Self) void {
     self.x = @divFloor(self.output.?.exclusive_width()-self.width, 2);
-    self.y = @divFloor(self.output.?.exclusive_width()-self.height, 2);
+    self.y = @divFloor(self.output.?.exclusive_height()-self.height, 2);
 }
 
 


### PR DESCRIPTION
Fix the issue introduced by d3b94b94d782395a2f6d08b3fe20f535d161bdf0, where floating windows are spawned at the bottom of the output.