### PR TITLE
When sending a window to a different output, move to active tag.

### DIFF
--- a/src/kwm/context.zig
+++ b/src/kwm/context.zig
@@ -512,6 +512,7 @@ pub fn send_to_output(self: *Self, window: *Window, direction: types.Direction) 
                 },
                 else => {}
             }
+            window.set_tag(new_output.tag);
         }
     }
 }


### PR DESCRIPTION
Hello, this might not be behaviour that you want, so feel free to ignore/deny this PR. It's also only 1 line so not really a big contribution. If there is some other way of doing this already then let me know.

I am used to the behaviour of `dwl`, where moving a window to a different output will automatically move it to the active tag of that output. I.E. if tag 1 is open on monitor 1, and tag 2 on monitor 2, moving a window from monitor 1 (tag 1) to monitor 2 will automatically move it to tag 2.