### PR TITLE
feat(binding): keybindings with grouped actions

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -525,7 +525,7 @@ fn try_load_user_config() ?make_fields_optional(Self) {
     _ = file.readAll(buffer) catch return null;
     buffer[stat.size] = 0;
 
-    @setEvalBranchQuota(7000);
+    @setEvalBranchQuota(10000);
     return zon.parse.fromSlice(
         make_fields_optional(Self),
         allocator,

--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -73,4 +73,9 @@ pub const Action = union(enum) {
     toggle_auto_swallow,
 
     reload_config,
+
+    group: struct {
+        actions: []const Action,
+    },
+
 };

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -610,6 +610,12 @@ fn handle_actions(self: *Self) void {
             .reload_config => {
                 context.reload_config();
             },
+
+            .group => |group| {
+                for (group.actions) |nested_action| {
+                    self.append_action(nested_action);
+                }
+            },
         }
     }
 }


### PR DESCRIPTION
Introduce a new `group` action type that allows multiple actions to be chained together and executed sequentially from a single keybinding.

Regarding https://github.com/kewuaa/kwm/issues/59

I'm still not sure how to document this usage in `config.def.zon`, maybe:

```zig
.{
    .keysym = "t",
    .modifiers = .{ .mod4 = true },
    .event = .{
        .click = .{
            .pressed = .{
                .group = .{
                    .actions = .{
                        .{ .switch_layout = .{ .layout = .tile } },
                        .{ .modify_tile_master_location = .{ .location = .left } },
                    },
                },
            },
        },
    },
},
.{
    .keysym = "t",
    .modifiers = .{ .mod4 = true, .shift = true },
    .event = .{
        .click = .{
            .pressed = .{
                .group = .{
                    .actions = .{
                        .{ .switch_layout = .{ .layout = .tile } },
                        .{ .modify_tile_master_location = .{ .location = .right } },
                    },
                },
            },
        },
    },
},
```

- <kbd>mod4</kbd> + <kbd>t</kbd>:  switch to left tile layout
- <kbd>mod4</kbd> + <kbd>shift</kbd> + <kbd>t</kbd>: switch to right tile layout
