### PR TITLE
Feat: focus_master_return

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -425,6 +425,24 @@
                 },
             },
             .{
+                .keysym = "h",
+                .modifiers = .{ .mod4 = true, .ctrl = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .focus_master_return,
+                    },
+                },
+            },
+            .{
+                .keysym = "l",
+                .modifiers = .{ .mod4 = true, .ctrl = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .focus_master_return,
+                    },
+                },
+            },
+            .{
                 .keysym = "b",
                 .modifiers = .{ .mod4 = true },
                 .event = .{

--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -61,6 +61,7 @@ pub const Action = union(enum) {
     toggle_sticky,
     toggle_swallow,
     zoom: struct { swap: bool },
+    focus_master_return,
     switch_layout: struct { layout: layout.Type },
     switch_to_previous_layout,
     toggle_bar,

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -549,6 +549,23 @@ fn handle_actions(self: *Self) void {
                     }
                 }
             },
+            .focus_master_return => {
+                if (context.focused_window()) |window| {
+                    if (window.floating) return;
+                    if (window.output) |output| {
+                        switch (output.current_layout()) {
+                            .tile, .deck => {
+                                const master = output.master_window() orelse return;
+                                context.focus(
+                                    if (window != master) master
+                                    else context.focused_before(window, true) orelse return,
+                                );
+                            },
+                            else => {}
+                        }
+                    }
+                }
+            },
             .switch_layout => |data| {
                 if (context.current_output) |output| {
                     output.set_current_layout(data.layout);


### PR DESCRIPTION
Switch to the master from anywhere in the stack, when the master is selected return to the client switched from using the same keybind. Very useful with #63 .

Insipred by dwm's [focusmaster-return](https://dwm.suckless.org/patches/focusmaster).