### PR TITLE
fix(bar): memory leak in dynamic status text rendering

### DIFF
--- a/src/kwm/bar.zig
+++ b/src/kwm/bar.zig
@@ -592,7 +592,12 @@ fn render_dynamic_component(self: *Self) void {
     );
     if (status_text.len > 0) status_block: {
         var texts: std.ArrayList(struct { pixman.Color, *const fcft.TextRun }) = .empty;
-        defer texts.deinit(utils.allocator);
+        defer {
+            for (texts.items) |item| {
+                item[1].destroy();
+            }
+            texts.deinit(utils.allocator);
+        }
 
         var i: usize = 0;
         var fg = normal_fg;


### PR DESCRIPTION
Ensure all font glyph resources are properly cleaned up during status updates.

This fixes a memory leak in the bar's status rendering, where update `mode_tag`
causes memory usage to grow overtime, especially noticeable when rapidly
switching modes with longer status text strings from `stdin` or `fifo`.
