### PR TITLE
allow skip nonfloating window in `focus_iter` too

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -479,7 +479,7 @@
                 .event = .{
                     .click = .{
                         .pressed = .{
-                            .focus_iter = .{ .direction = .forward, .skip_floating = true },
+                            .focus_iter = .{ .direction = .forward, .skip = .floating },
                         },
                     },
                 },
@@ -490,7 +490,7 @@
                 .event = .{
                     .click = .{
                         .pressed = .{
-                            .focus_iter = .{ .direction = .reverse, .skip_floating = true },
+                            .focus_iter = .{ .direction = .reverse, .skip = .floating },
                         },
                     },
                 },

--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -23,7 +23,7 @@ pub const Action = union(enum) {
     },
     focus_iter: struct {
         direction: types.Direction,
-        skip_floating: bool = false,
+        skip: types.WindowIterSkip = .none,
     },
     focus_output_iter: struct {
         direction: types.Direction,

--- a/src/kwm/context.zig
+++ b/src/kwm/context.zig
@@ -453,7 +453,7 @@ pub fn focused_window(self: *Self) ?*Window {
 }
 
 
-pub fn focus_iter(self: *Self, direction: types.Direction, skip_floating: bool) void {
+pub fn focus_iter(self: *Self, direction: types.Direction, skip: types.WindowIterSkip) void {
     log.debug("focus iter: {s}", .{ @tagName(direction) });
 
     if (self.focused_window()) |window| {
@@ -466,7 +466,11 @@ pub fn focus_iter(self: *Self, direction: types.Direction, skip_floating: bool) 
             defer win = new_window;
             if (new_window == window) break;
             if (new_window.is_visible_in(window.output.?)) {
-                if (skip_floating and new_window.floating) continue;
+                switch (skip) {
+                    .none => {},
+                    .floating => if (new_window.floating) continue,
+                    .nonfloating => if (!new_window.floating) continue,
+                }
                 self.focus(new_window);
                 break;
             }

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -458,7 +458,7 @@ fn handle_actions(self: *Self) void {
                 context.switch_mode(data.mode);
             },
             .focus_iter => |data| {
-                context.focus_iter(data.direction, data.skip_floating);
+                context.focus_iter(data.direction, data.skip);
             },
             .focus_output_iter => |data| {
                 context.focus_output_iter(data.direction);

--- a/src/kwm/types.zig
+++ b/src/kwm/types.zig
@@ -34,3 +34,9 @@ pub const LayoutMasterLocation = enum {
     top,
     bottom,
 };
+
+pub const WindowIterSkip = enum {
+    none,
+    floating,
+    nonfloating,
+};


### PR DESCRIPTION
reimplement of #78 