### PR TITLE
enhance `switch_mode`

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -248,18 +248,8 @@
                 .event = .{
                     .click = .{
                         .pressed = .{
-                            .switch_mode = .{ .mode = "floating" },
+                            .switch_mode = .{ .mode = "floating", .auto_quit = .once_unbound_pressed },
                         },
-                    },
-                },
-            },
-            .{
-                .mode = "floating",
-                .keysym = "f",
-                .modifiers = .{ .mod4 = true, .ctrl = true },
-                .event = .{
-                    .click = .{
-                        .pressed = .{ .switch_mode = .{ .mode = "default" } },
                     },
                 },
             },

--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -47,6 +47,12 @@ pub const Action = union(enum) {
     },
     switch_mode: struct {
         mode: []const u8,
+        auto_quit: enum {
+            disabled,
+            once_pressed,
+            once_bound_pressed,
+            once_unbound_pressed,
+        } = .disabled,
     },
     toggle_fullscreen: struct {
         in_window: bool = false,
@@ -78,5 +84,4 @@ pub const Action = union(enum) {
     group: struct {
         actions: []const Action,
     },
-
 };

--- a/src/kwm/binding/xkb_binding.zig
+++ b/src/kwm/binding/xkb_binding.zig
@@ -82,11 +82,27 @@ fn rwm_xkb_binding_listener(rwm_xkb_binding: *river.XkbBindingV1, event: river.X
 
     switch (xkb_binding.event) {
         .click => |data| {
-            xkb_binding.seat.append_action(switch (event) {
-                .pressed => data.pressed orelse return,
-                .released => data.released orelse return,
-                .stop_repeat => return,
-            });
+            switch (event) {
+                .pressed => if (data.pressed) |action| {
+                    // force entering chorded at released
+                    if (action != .switch_mode or action.switch_mode.auto_quit == .disabled) {
+                        xkb_binding.seat.append_action(action);
+                    }
+                },
+                .released => {
+                    if (data.released) |action| {
+                        xkb_binding.seat.append_action(action);
+                    }
+
+                    if (data.pressed) |action| {
+                        // entering chorded at last
+                        if (action == .switch_mode and action.switch_mode.auto_quit != .disabled) {
+                            xkb_binding.seat.append_action(action);
+                        }
+                    }
+                },
+                .stop_repeat => {}
+            }
         },
         .repeat => |action| {
             const context = Context.get();
@@ -104,5 +120,17 @@ fn rwm_xkb_binding_listener(rwm_xkb_binding: *river.XkbBindingV1, event: river.X
                 xkb_binding.seat.append_action(action);
             }
         },
+    }
+
+    // exiting chorded at released
+    switch (xkb_binding.seat.chorded.state) {
+        .entering, .exiting => unreachable,
+        .enabled => if (event == .released) {
+            switch (xkb_binding.seat.chorded.quit_mode) {
+                .once_pressed, .once_bound_pressed => xkb_binding.seat.chorded.state = .exiting,
+                .once_unbound_pressed => {}
+            }
+        },
+        .disabled => {}
     }
 }

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -29,9 +29,23 @@ wl_seat: ?*wl.Seat = null,
 wl_pointer: ?*wl.Pointer = null,
 rwm_seat: *river.SeatV1,
 rwm_layer_shell_seat: *river.LayerShellSeatV1,
+rwm_xkb_binding_seat: *river.XkbBindingsSeatV1,
 
 mode_buffer: [16]u8 = undefined,
 mode: ?[]const u8 = null,
+chorded: struct {
+    state: enum {
+        entering,
+        enabled,
+        exiting,
+        disabled,
+    } = .disabled,
+    quit_mode: enum {
+        once_pressed,
+        once_bound_pressed,
+        once_unbound_pressed,
+    },
+} = .{ .state = .disabled, .quit_mode = .once_pressed },
 button: types.Button = undefined,
 focus_exclusive: bool = false,
 previous_focused: union(enum) {
@@ -58,10 +72,12 @@ pub fn create(rwm_seat: *river.SeatV1) !*Self {
 
     const rwm_layer_shell_seat = try context.rwm_layer_shell.getSeat(rwm_seat);
     errdefer rwm_layer_shell_seat.destroy();
+    const rwm_xkb_binding_seat = try context.rwm_xkb_bindings.getSeat(rwm_seat);
 
     seat.* = .{
         .rwm_seat = rwm_seat,
         .rwm_layer_shell_seat = rwm_layer_shell_seat,
+        .rwm_xkb_binding_seat = rwm_xkb_binding_seat,
         .unhandled_actions = try .initCapacity(utils.allocator, 2),
         .xkb_bindings = .init(utils.allocator),
         .pointer_bindings = .init(utils.allocator),
@@ -73,6 +89,7 @@ pub fn create(rwm_seat: *river.SeatV1) !*Self {
 
     rwm_seat.setListener(*Self, rwm_seat_listener, seat);
     rwm_layer_shell_seat.setListener(*Self, rwm_layer_shell_seat_listener, seat);
+    rwm_xkb_binding_seat.setListener(*Self, rwm_xkb_binding_seat_listener, seat);
 
     return seat;
 }
@@ -143,13 +160,36 @@ pub fn manage(self: *Self) void {
 
     const context = Context.get();
 
-    if (self.mode == null or !mem.eql(u8, self.mode.?, context.mode)) {
-        defer self.mode = fmt.bufPrint(&self.mode_buffer, "{s}", .{ context.mode }) catch unreachable;
+    if (self.chorded.state != .enabled) {
+        if (self.chorded.state == .exiting) {
+            log.debug("<{*}> exiting chorded", .{ self });
 
-        if (self.mode) |mode| {
-            self.toggle_bindings(mode, false);
+            // restore mode
+            self.toggle_bindings(context.mode, false);
+            context.switch_mode(self.mode.?);
+
+            // reset self.mode, sync with context.mode later
+            self.mode = null;
+
+            self.chorded.state = .disabled;
         }
-        self.toggle_bindings(context.mode, true);
+
+        if (self.mode == null or !mem.eql(u8, self.mode.?, context.mode)) {
+            self.toggle_bindings(context.mode, true);
+            if (self.mode) |mode| self.toggle_bindings(mode, false);
+
+            if (self.chorded.state == .entering) {
+                log.debug("<{*}> entering chorded", .{ self });
+
+                self.chorded.state = .enabled;
+            } else {
+                self.mode = fmt.bufPrint(&self.mode_buffer, "{s}", .{ context.mode }) catch unreachable;
+            }
+        }
+    }
+
+    if (self.chorded.state == .enabled){
+        self.rwm_xkb_binding_seat.ensureNextKeyEaten();
     }
 }
 
@@ -455,7 +495,26 @@ fn handle_actions(self: *Self) void {
                 }
             },
             .switch_mode => |data| {
+                if (mem.eql(u8, data.mode, context.mode)) continue;
+
                 context.switch_mode(data.mode);
+
+                if (data.auto_quit != .disabled) {
+                    switch (self.chorded.state) {
+                        .entering => log.warn("<{*}> try repeatly entering chorded", .{ self }),
+                        .enabled => log.warn("<{*}> try recursively entering chorded", .{ self }),
+                        .exiting => unreachable,
+                        .disabled => {
+                            self.chorded.state = .entering;
+                            self.chorded.quit_mode = switch (data.auto_quit) {
+                                .disabled => unreachable,
+                                .once_pressed => .once_pressed,
+                                .once_bound_pressed => .once_bound_pressed,
+                                .once_unbound_pressed => .once_unbound_pressed,
+                            };
+                        }
+                    }
+                }
             },
             .focus_iter => |data| {
                 context.focus_iter(data.direction, data.skip_floating);
@@ -819,6 +878,24 @@ fn rwm_layer_shell_seat_listener(rwm_layer_shell_seat: *river.LayerShellSeatV1, 
             log.debug("<{*}> focus none", .{ seat });
 
             seat.focus_exclusive = false;
+        }
+    }
+}
+
+
+fn rwm_xkb_binding_seat_listener(rwm_xkb_binding_seat: *river.XkbBindingsSeatV1, event: river.XkbBindingsSeatV1.Event, seat: *Self) void {
+    std.debug.assert(rwm_xkb_binding_seat == seat.rwm_xkb_binding_seat);
+
+    switch (event) {
+        .ate_unbound_key => {
+            log.debug("<{*}> ate_unbound_key", .{ seat });
+
+            std.debug.assert(seat.chorded.state == .enabled);
+
+            switch (seat.chorded.quit_mode) {
+                .once_pressed, .once_unbound_pressed => seat.chorded.state = .exiting,
+                .once_bound_pressed => {}
+            }
         }
     }
 }


### PR DESCRIPTION
Allows temporary switching to other modes, automatically switching back to the original mode upon triggering any key binding or pressing any other key.
It allows for easier movement or resizing of the window. Like:
```zig
            // move
            .{
                .keysym = "w",
                .modifiers = .{ .mod4 = true },
                .event = .{
                    .click = .{
                        .pressed = .{
                            .switch_mode = .{ .mode = "move", .quick_back = true },
                        },
                    },
                },
            },
            .{
                .mode = "move",
                .keysym = "l",
                .modifiers = .{},
                .event = .{
                    .repeat = .{
                        .move = .{ .step = .{ .horizontal = 10 } },
                    },
                },
            },
            .{
                .mode = "move",
                .keysym = "h",
                .modifiers = .{},
                .event = .{
                    .repeat = .{
                        .move = .{ .step = .{ .horizontal = -10 } },
                    },
                },
            },
            .{
                .mode = "move",
                .keysym = "j",
                .modifiers = .{},
                .event = .{
                    .repeat = .{
                        .move = .{ .step = .{ .vertical = 10 } },
                    },
                },
            },
            .{
                .mode = "move",
                .keysym = "k",
                .modifiers = .{},
                .event = .{
                    .repeat = .{
                        .move = .{ .step = .{ .vertical = -10 } },
                    },
                },
            },
```
You could pressed `mod4+w` to enter `move` mode, use `j` `k` `l` `h` to move window, and once you released, it will quickly switch back to `default` mode.