### PR TITLE
Feat: filtering occupied and uncoupled tags in shift_tag

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -713,7 +713,7 @@
                 .event = .{
                     .click = .{
                         .pressed = .{
-                            .shift_tag = .{ .direction = .forward },
+                            .shift_tag = .{ .direction = .forward, .skip_unoccupied = true },
                         },
                     },
                 },
@@ -724,7 +724,51 @@
                 .event = .{
                     .click = .{
                         .pressed = .{
+                            .shift_tag = .{ .direction = .reverse, .skip_unoccupied = true },
+                        },
+                    },
+                },
+            },
+            .{
+                .keysym = "apostrophe",
+                .modifiers = .{ .mod4 = true, .shift = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .{
+                            .shift_tag = .{ .direction = .forward },
+                        },
+                    },
+                },
+            },
+            .{
+                .keysym = "semicolon",
+                .modifiers = .{ .mod4 = true, .shift = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .{
                             .shift_tag = .{ .direction = .reverse },
+                        },
+                    },
+                },
+            },
+            .{
+                .keysym = "apostrophe",
+                .modifiers = .{ .mod4 = true, .ctrl = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .{
+                            .shift_tag = .{ .direction = .forward, .skip_occupied = true },
+                        },
+                    },
+                },
+            },
+            .{
+                .keysym = "semicolon",
+                .modifiers = .{ .mod4 = true, .ctrl = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .{
+                            .shift_tag = .{ .direction = .reverse, .skip_occupied = true },
                         },
                     },
                 },

--- a/doc/kwm.1
+++ b/doc/kwm.1
@@ -5,7 +5,7 @@
 .nh
 .ad l
 .\" Begin generated content:
-.TH "KWM" "1" "2026-03-18" "kwm" "kewuaa's window manager"
+.TH "KWM" "1" "2026-03-22" "kwm" "kewuaa's window manager"
 .PP
 .SH NAME
 .PP
@@ -183,7 +183,17 @@ Switch to the previous tag.\&
 .RE
 Mod4-['\&;]
 .RS 4
-Shift to the next/previous tag.\&
+Shift each tag to its next/previous occupied tag.\&
+.PP
+.RE
+Mod4-Shift-['\&;]
+.RS 4
+Shift each tag to its next/previous tag.\&
+.PP
+.RE
+Mod4-Ctrl-['\&;]
+.RS 4
+Shift each tag to its next/previous unoccupied tag.\&
 .PP
 .RE
 Mod4-[1-9]

--- a/doc/kwm.1.scd
+++ b/doc/kwm.1.scd
@@ -116,7 +116,13 @@ Mod4-Tab
 	Switch to the previous tag.
 
 Mod4-\[';\]
-	Shift to the next/previous tag.
+	Shift each tag to its next/previous occupied tag.
+
+Mod4-Shift-\[';\]
+	Shift each tag to its next/previous tag.
+
+Mod4-Ctrl-\[';\]
+	Shift each tag to its next/previous unoccupied tag.
 
 Mod4-[1-9]
 	Set the output tag.

--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -62,7 +62,11 @@ pub const Action = union(enum) {
     toggle_output_tag: struct { mask: u32 },
     toggle_window_tag: struct { mask: u32 },
     switch_to_previous_tag,
-    shift_tag: struct { direction: types.Direction },
+    shift_tag: struct {
+        direction: types.Direction,
+        skip_unoccupied: bool = false,
+        skip_occupied: bool = false,
+    },
     toggle_floating,
     toggle_sticky,
     toggle_swallow,

--- a/src/kwm/output.zig
+++ b/src/kwm/output.zig
@@ -213,12 +213,13 @@ pub fn switch_to_previous_tag(self: *Self) void {
 }
 
 
-pub fn shift_tag(self: *Self, direction: types.Direction) void {
+pub fn shift_tag(self: *Self, direction: types.Direction, skip_unoccupied: bool, skip_occupied: bool) void {
     const config = Config.get();
     const context = Context.get();
     const total_tags = config.tags.len;
 
-    log.debug("<{*}> shift tag: {}", .{ self, direction });
+    log.debug("<{*}> shift tag: direction={}, skip_unoccupied={}, skip_occupied={}",
+        .{ self, direction, skip_unoccupied, skip_occupied });
 
     const current_tags = self.tag;
     if (current_tags == 0) {
@@ -232,6 +233,19 @@ pub fn shift_tag(self: *Self, direction: types.Direction) void {
         if (window.output == self) occupied_tags |= window.tag;
     }
 
+    const all_tags_mask = (@as(u32, 1) << @as(u5, @intCast(total_tags))) - 1;
+    const unoccupied_tags = all_tags_mask ^ occupied_tags;
+
+    if (skip_occupied and !skip_unoccupied and unoccupied_tags == 0) {
+        log.debug("<{*}> no unoccupied tags available", .{ self });
+        return;
+    }
+
+    if (skip_unoccupied and !skip_occupied and occupied_tags == 0) {
+        log.debug("<{*}> no occupied tags available", .{ self });
+        return;
+    }
+
     if (occupied_tags == 0) {
         var new_tags = current_tags;
         if (direction == .forward) {
@@ -239,7 +253,7 @@ pub fn shift_tag(self: *Self, direction: types.Direction) void {
         } else {
             new_tags = (new_tags >> 1) | (new_tags << @as(u5, @intCast(total_tags - 1)));
         }
-        new_tags &= (@as(u32, 1) << @as(u5, @intCast(total_tags))) - 1;
+        new_tags &= all_tags_mask;
         if (new_tags != 0) self.set_tag(new_tags);
         return;
     }
@@ -261,20 +275,37 @@ pub fn shift_tag(self: *Self, direction: types.Direction) void {
                     test_index - 1;
 
                 const test_mask = @as(u32, 1) << @as(u5, @intCast(test_index));
-                if (occupied_tags & test_mask != 0) {
+                const is_occupied = occupied_tags & test_mask != 0;
+
+                const should_select =
+                    if (skip_occupied and skip_unoccupied)
+                        false
+                    else if (skip_occupied)
+                        !is_occupied
+                    else if (skip_unoccupied)
+                        is_occupied
+                    else
+                        true;
+
+                if (should_select) {
                     new_tags |= test_mask;
                     found = true;
                     break;
                 }
             }
 
-            if (!found and (occupied_tags & tag_mask != 0)) new_tags |= tag_mask;
+            if (!found) {
+                new_tags |= tag_mask;
+            }
         }
         tag_mask <<= 1;
     }
 
-    if (new_tags != 0) self.set_tag(new_tags)
-    else log.warn("<{*}> no valid tags found after shifting", .{ self });
+    if (new_tags != 0 and new_tags != current_tags) {
+        self.set_tag(new_tags);
+    } else {
+        log.debug("<{*}> no valid tags found after shifting", .{ self });
+    }
 }
 
 

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -568,7 +568,7 @@ fn handle_actions(self: *Self) void {
             },
             .shift_tag => |data| {
                 if (context.current_output) |output| {
-                    output.shift_tag(data.direction);
+                    output.shift_tag(data.direction, data.skip_unoccupied, data.skip_occupied);
                 }
             },
             .toggle_floating => {


### PR DESCRIPTION
| keybindings | arguments | behavior |
|---|:---|:---|
|<kbd>Mod4</kbd> <kbd>;</kbd>/<kbd>'</kbd>| .direction = .forward/backword, .skip_unoccupied = true | each active tag shifts to its next/previous occupied tag |
|<kbd>Mod4</kbd> <kbd>Shift</kbd> <kbd>;</kbd>/<kbd>'</kbd>| .direction = .forward/backword | each active tag shifts to its next/previous tag |
|<kbd>Mod4</kbd> <kbd>Ctrl</kbd> <kbd>;</kbd>/<kbd>'</kbd>| .direction = .forward/backword, .skip_occupied = true | each active tag shifts to its next/previous unoccupied tag |

This covers the use case in https://github.com/kewuaa/kwm/pull/106.
