### PR TITLE
Feat: floating window indicator in the bar

### DIFF
--- a/src/kwm/bar.zig
+++ b/src/kwm/bar.zig
@@ -605,6 +605,48 @@ fn render_dynamic_component(self: *Self) void {
             );
         }
 
+        if (window.floating) {
+            const box_size, const box_offset = self.get_box();
+            const box_y = if (window.sticky)
+                y + @as(i16, @intCast(h)) - @as(i16, @intCast(box_size)) - 1
+            else
+                y + 1;
+
+            const box = [_]pixman.Rectangle16 {
+                .{
+                    .x = x + box_offset,
+                    .y = box_y,
+                    .width = box_size,
+                    .height = box_size,
+                }
+            };
+
+            _ = pixman.Image.fillRectangles(
+                .src,
+                buffer.image,
+                &select_fg,
+                1,
+                &box,
+            );
+
+            const border = 1;
+            const inner = [_]pixman.Rectangle16 {
+                .{
+                    .x = box[0].x + border,
+                    .y = box[0].y + border,
+                    .width = box[0].width - 2*border,
+                    .height = box[0].height - 2*border,
+                }
+            };
+            _ = pixman.Image.fillRectangles(
+                .src,
+                buffer.image,
+                &select_bg,
+                1,
+                &inner,
+            );
+        }
+
         if (window.title) |title| {
             x += self.render_str(
                 buffer,

--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -426,6 +426,12 @@ pub fn toggle_floating(self: *Self) void {
 
     self.floating = !self.floating;
 
+    if (comptime build_options.bar_enabled) {
+        if (self.output) |output| {
+            output.bar.damage(.title);
+        }
+    }
+
     const config = Config.get();
 
     if (!config.remember_floating_geometry) return;


### PR DESCRIPTION
Add a floating window indicator in the bar:

![floating_indicator](https://github.com/user-attachments/assets/b545dca4-f9b3-4119-a6ff-b124155bc0da)

I find it very confusing when setting `remember_floating_geometry = true` and toggling a window to be floating sometimes.

This also mimics the dwm bar's floating indicator, except the floating indicator will be drawn on the bottom if sticky indicator exists.