### PR TITLE
Fix(bar): update layout_tag after changing location

### DIFF
--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -686,11 +686,14 @@ fn handle_actions(self: *Self) void {
                 }
             },
             .modify_master_location => |data| {
-                if (context.current_output) |output| {
+                if (context.current_output) |output| blk: {
                     switch (output.current_layout()) {
                         .tile => output.layout.tile.master_location = data.location,
                         .deck => output.layout.deck.master_location = data.location,
-                        else => {},
+                        else => break :blk,
+                    }
+                    if (comptime build_options.bar_enabled) {
+                        output.bar.damage(.layout);
                     }
                 }
             },
@@ -701,6 +704,9 @@ fn handle_actions(self: *Self) void {
                             .horizontal => .vertical,
                             .vertical => .horizontal,
                         };
+                        if (comptime build_options.bar_enabled) {
+                            output.bar.damage(.layout);
+                        }
                     }
                 }
             },


### PR DESCRIPTION
Call `bar.damage()` immediately after updating layout properties. This fixes an issue layout_tag isn't updated before switching to another layout and back.