### PR TITLE
feat: host-specific configuration

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -218,6 +218,7 @@
         //              }
         //              the corrosponding action will only trigger once when key pressed or released
         //              the pressed action and released action could define at the same time
+        //       host: rule pattern to match against system hostname, the binding will only be configured on matching hosts
         .key = .{
             .{
                 .keysym = "r",
@@ -1005,6 +1006,7 @@
     //      disable_swallow: bool, if set true, the window could not swallow any other windows
     //      scroller_mfact: f32, initial mfact of the window for scroller layout
     //      attach_mode: like `default_attach_mode`, change attach_mode for window matched
+    //      host: rule pattern to match against system hostname, the window rule will only apply on matching hosts
     .window_rules = .{
         .{ .app_id = .{ .str = "", .match_null = true }, .floating = true },
         .{ .app_id = .{ .str = "zenity" }, .floating = true },
@@ -1021,6 +1023,7 @@
     //      presentation_mode: presentation mode, .vsync or .async
     //      layout: same as `layout` before but you only need to specify the values you want to change
     //      default_layout: same as `default_layout` before
+    //      host: rule pattern to match against system hostname, the output rule will only apply on matching hosts
     .output_rules = .{
         //
     },
@@ -1031,6 +1034,7 @@
     //
     //      repeat_info: .{ .rate = i32, .delay = i32 }
     //      scroll_factor: f64
+    //      host: rule pattern to match against system hostname, the input rule will only apply on matching hosts
     .input_device_rules = .{
         .{ .repeat_info = .{ .rate = 50, .delay = 300 } },
     },
@@ -1079,6 +1083,7 @@
     //      disable_while_typing: .enabled or .disabled
     //      disable_while_trackpointing: .enabled or .disabled
     //      rotation_angle: u32
+    //      host: rule pattern to match against system hostname, the input rule will only apply on matching hosts
     .libinput_device_rules = .{
         .{ .name = .{ .str = ".*[tT]ouchpad", .regex = true }, .tap = .enabled, .drag = .enabled, .natural_scroll = .enabled },
         .{ .tap = .enabled, .drag = .enabled }
@@ -1106,6 +1111,7 @@
     //                  .options = ?[]const u8,
     //              }
     //          }
+    //      host: rule pattern to match against system hostname, the keyboard rule will only apply on matching hosts
     .xkb_keyboard_rules = .{
         //
     },

--- a/src/config.zig
+++ b/src/config.zig
@@ -14,6 +14,7 @@ const kwm = @import("kwm");
 const rule = @import("config/rule.zig");
 const constants = @import("config/constants.zig");
 pub const meta = @import("config/meta.zig");
+const Pattern = @import("config/rule/pattern.zig");
 
 var allocator: mem.Allocator = undefined;
 
@@ -29,7 +30,6 @@ pub const OutputRule = rule.Output;
 pub const InputDeviceRule = rule.InputDevice;
 pub const LibinputDeviceRule = rule.LibinputDevice;
 pub const XkbKeyboardRule = rule.XkbKeyboard;
-
 
 env: []const struct { []const u8, []const u8 },
 
@@ -133,6 +133,7 @@ bindings: struct {
         keysym: []const u8,
         modifiers: river.SeatV1.Modifiers,
         event: kwm.XkbBindingEvent,
+        host: ?Pattern = null,
     },
     pointer: []const struct {
         mode: []const u8 = default_mode,

--- a/src/config/rule/input_device.zig
+++ b/src/config/rule/input_device.zig
@@ -11,9 +11,16 @@ name: ?Pattern = null,
 
 repeat_info: ?kwm.KeyboardRepeatInfo = null,
 scroll_factor: ?f64 = null,
+host: ?Pattern = null,
 
 
-pub fn match(self: *const Self, name: ?[]const u8) bool {
+pub fn match(self: *const Self, name: ?[]const u8, hostname: ?[]const u8) bool {
+    if (self.host) |host| {
+        if (!host.is_match(hostname)) {
+            return false;
+        }
+    }
+
     if (self.name) |pattern| {
         log.debug("try match name: `{s}` with {*}({*}: `{s}`)", .{ name orelse "null", self, &pattern, pattern.str });
 

--- a/src/config/rule/libinput_device.zig
+++ b/src/config/rule/libinput_device.zig
@@ -33,9 +33,16 @@ scroll_button_lock: ?river.LibinputDeviceV1.ScrollButtonLockState = null,
 disable_while_typing: ?river.LibinputDeviceV1.DwtState = null,
 disable_while_trackpointing: ?river.LibinputDeviceV1.DwtpState = null,
 rotation_angle: ?u32 = null,
+host: ?Pattern = null,
 
 
-pub fn match(self: *const Self, name: ?[]const u8) bool {
+pub fn match(self: *const Self, name: ?[]const u8, hostname: ?[]const u8) bool {
+    if (self.host) |host| {
+        if (!host.is_match(hostname)) {
+            return false;
+        }
+    }
+
     if (self.name) |pattern| {
         log.debug("try match name: `{s}` with {*}({*}: `{s}`)", .{ name orelse "null", self, &pattern, pattern.str });
 

--- a/src/config/rule/output.zig
+++ b/src/config/rule/output.zig
@@ -13,13 +13,19 @@ const Pattern = @import("pattern.zig");
 
 
 name: ?Pattern = null,
-
 presentation_mode: ?river.OutputV1.PresentationMode = null,
 default_layout: ?kwm.Layout.Type = null,
 layout: ?meta.make_fields_optional(kwm.Layout) = null,
+host: ?Pattern = null,
 
 
-pub fn match(self: *const Self, name: ?[]const u8) bool {
+pub fn match(self: *const Self, name: ?[]const u8, hostname: ?[] const u8) bool {
+    if (self.host) |host| {
+        if (!host.is_match(hostname)) {
+            return false;
+        }
+    }
+
     if (self.name) |pattern| {
         log.debug("try match name: `{s}` with {*}({*}: `{s}`)", .{ name orelse "null", self, &pattern, pattern.str });
 

--- a/src/config/rule/window.zig
+++ b/src/config/rule/window.zig
@@ -29,9 +29,16 @@ is_terminal: ?bool = null,
 disable_swallow: ?bool = null,
 scroller_mfact: ?f32 = null,
 attach_mode: ?kwm.WindowAttachMode = null,
+host: ?Pattern = null,
 
 
-pub fn match(self: *const Self, app_id: ?[]const u8, title: ?[]const u8) bool {
+pub fn match(self: *const Self, app_id: ?[]const u8, title: ?[]const u8, hostname: ?[] const u8) bool {
+    if (self.host) |host| {
+        if (!host.is_match(hostname)) {
+            return false;
+        }
+    }
+
     if (self.app_id) |pattern| {
         log.debug("try match app_id: `{s}` with {*}({*}: `{s}`)", .{ app_id orelse "null", self, &pattern, pattern.str });
 

--- a/src/config/rule/xkb_keyboard.zig
+++ b/src/config/rule/xkb_keyboard.zig
@@ -14,9 +14,15 @@ numlock: ?kwm.KeyboardNumlockState = null,
 capslock: ?kwm.KeyboardCapslockState = null,
 layout: ?kwm.KeyboardLayout = null,
 keymap: ?kwm.Keymap = null,
+host: ?Pattern = null,
 
+pub fn match(self: *const Self, name: ?[]const u8, hostname: ?[]const u8) bool {
+    if (self.host) |host| {
+        if (!host.is_match(hostname)) {
+            return false;
+        }
+    }
 
-pub fn match(self: *const Self, name: ?[]const u8) bool {
     if (self.name) |pattern| {
         log.debug("try match name: `{s}` with {*}({*}: `{s}`)", .{ name orelse "null", self, &pattern, pattern.str });
 

--- a/src/kwm/context.zig
+++ b/src/kwm/context.zig
@@ -29,6 +29,7 @@ const XkbKeyboard = @import("xkb_keyboard.zig");
 
 var ctx: ?Self = null;
 var mode_buffer: [16]u8 = undefined;
+var hostname_buffer: [posix.HOST_NAME_MAX]u8 = undefined;
 
 
 wl_registry: *wl.Registry,
@@ -65,6 +66,7 @@ bar_status_fd: ?posix.fd_t = null,
 terminal_windows: std.AutoHashMap(i32, *Window) = undefined,
 
 mode: []const u8,
+hostname: []const u8,
 running: bool = true,
 env: process.EnvMap = undefined,
 startup_processes: std.ArrayList(?process.Child) = .empty,
@@ -111,6 +113,7 @@ pub fn init(
         .key_repeat = undefined,
         .terminal_windows = .init(utils.allocator),
         .mode = fmt.bufPrint(&mode_buffer, "{s}", .{ Config.default_mode }) catch @panic("mode name too long"),
+        .hostname = std.posix.gethostname(&hostname_buffer) catch @panic("hostname too long")
     };
     ctx.?.seats.init();
     ctx.?.outputs.init();

--- a/src/kwm/input_device.zig
+++ b/src/kwm/input_device.zig
@@ -9,6 +9,7 @@ const wl = wayland.client.wl;
 const river = wayland.client.river;
 
 const Config = @import("config");
+const Context = @import("context.zig");
 
 const utils = @import("utils.zig");
 
@@ -73,9 +74,10 @@ pub fn apply_rules(self: *Self) void {
     log.debug("<{*}> apply rules", .{ self });
 
     const config = Config.get();
+    const context = Context.get();
 
     for (config.input_device_rules) |rule| {
-        if (rule.match(self.name)) {
+        if (rule.match(self.name, context.hostname)) {
             self.apply_rule(&rule);
             break;
         }

--- a/src/kwm/libinput_device.zig
+++ b/src/kwm/libinput_device.zig
@@ -9,6 +9,7 @@ const wl = wayland.client.wl;
 const river = wayland.client.river;
 
 const Config = @import("config");
+const Context = @import("context.zig");
 
 const utils = @import("utils.zig");
 const types = @import("types.zig");
@@ -113,9 +114,10 @@ pub fn apply_rules(self: *Self) void {
     log.debug("<{*}> apply rules", .{ self });
 
     const config = Config.get();
+    const context = Context.get();
 
     for (config.libinput_device_rules) |rule| {
-        if (rule.match((self.input_device orelse return).name)) {
+        if (rule.match((self.input_device orelse return).name, context.hostname)) {
             self.apply_rule(&rule);
             break;
         }

--- a/src/kwm/output.zig
+++ b/src/kwm/output.zig
@@ -121,9 +121,10 @@ pub fn apply_rules(self: *Self) void {
     log.debug("<{*}> apply rules", .{ self });
 
     const config = Config.get();
+    const context = Context.get();
 
     for (config.output_rules) |rule| {
-        if (rule.match(self.name)) {
+        if (rule.match(self.name, context.hostname)) {
             self.apply_rule(&rule);
             break;
         }

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -286,6 +286,7 @@ pub fn refresh_xursor_theme(self: *Self) void {
 pub fn create_bindings(self: *Self) void {
     log.debug("<{*}> create bindings", .{ self });
 
+    const context = Context.get();
     const config = Config.get();
 
     for (config.bindings.key) |key_binding| {
@@ -294,6 +295,11 @@ pub fn create_bindings(self: *Self) void {
                 log.err("<{*}> put a new xkb binding list failed: {}", .{ self, err });
                 continue;
             };
+        }
+        if (key_binding.host) |host| {
+            if (!host.is_match(context.hostname)) {
+                continue;
+            }
         }
         const list = self.xkb_bindings.getPtr(key_binding.mode).?;
 

--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -671,9 +671,10 @@ pub fn apply_rules(self: *Self) void {
     log.debug("<{*}> apply rules", .{ self });
 
     const config = Config.get();
+    const context = Context.get();
 
     for (config.window_rules) |rule| {
-        if (rule.match(self.app_id, self.title)) {
+        if (rule.match(self.app_id, self.title, context.hostname)) {
             self.apply_rule(&rule);
             break;
         }

--- a/src/kwm/xkb_keyboard.zig
+++ b/src/kwm/xkb_keyboard.zig
@@ -134,9 +134,10 @@ pub fn apply_rules(self: *Self) void {
     log.debug("<{*}> apply rules", .{ self });
 
     const config = Config.get();
+    const context = Context.get();
 
     for (config.xkb_keyboard_rules) |rule| {
-        if (rule.match((self.input_device orelse return).name)) {
+        if (rule.match((self.input_device orelse return).name, context.hostname)) {
             self.apply_rule(&rule);
             break;
         }


### PR DESCRIPTION
This implements host-specific configuration by allowing the user to set a `host` property in various places. It will be matched against the running system's host name.

This allows a single `config.zon` to apply to multiple systems and yet offer some distinct behaviour for each.

Reference: https://github.com/kewuaa/kwm/issues/119