### PR TITLE
optimize layer rendering logic

### DIFF
--- a/src/kwm/context.zig
+++ b/src/kwm/context.zig
@@ -26,6 +26,7 @@ const KeyRepeat = @import("key_repeat.zig");
 const InputDevice = @import("input_device.zig");
 const LibinputDevice = @import("libinput_device.zig");
 const XkbKeyboard = @import("xkb_keyboard.zig");
+const ShellSurface = @import("shell_surface.zig");
 
 var ctx: ?Self = null;
 var mode_buffer: [16]u8 = undefined;
@@ -45,6 +46,10 @@ rwm_input_manager: ?*river.InputManagerV1,
 rwm_libinput_config: ?*river.LibinputConfigV1,
 rwm_xkb_config: ?*river.XkbConfigV1,
 
+// seperate layer between floating and nonfloating
+wl_surface: *wl.Surface = undefined,
+layer_marker: ShellSurface = undefined,
+
 seats: wl.list.Head(Seat, .link) = undefined,
 current_seat: ?*Seat = null,
 
@@ -55,6 +60,7 @@ input_devices: wl.list.Head(InputDevice, .link) = undefined,
 libinput_devices: wl.list.Head(LibinputDevice, .link) = undefined,
 xkb_keyboards: wl.list.Head(XkbKeyboard, .link) = undefined,
 
+window_to_lift: ?*Window = null,
 windows: wl.list.Head(Window, .link) = undefined,
 focus_stack: wl.list.Head(Window, .flink) = undefined,
 
@@ -84,7 +90,7 @@ pub fn init(
     rwm_input_manager: *river.InputManagerV1,
     rwm_libinput_config: *river.LibinputConfigV1,
     rwm_xkb_config: *river.XkbConfigV1,
-) void {
+) !void {
     // initialize once
     if (ctx != null) return;
 
@@ -110,8 +116,19 @@ pub fn init(
         .rwm_xkb_config = rwm_xkb_config,
         .key_repeat = undefined,
         .terminal_windows = .init(utils.allocator),
-        .mode = fmt.bufPrint(&mode_buffer, "{s}", .{ Config.default_mode }) catch @panic("mode name too long"),
+        .mode = fmt.bufPrint(&mode_buffer, "{s}", .{ Config.default_mode }) catch return error.ModeNameTooLong,
     };
+
+    const wl_surface = try wl_compositor.createSurface();
+    errdefer wl_surface.destroy();
+    const wl_region = try wl_compositor.createRegion();
+    defer wl_region.destroy();
+    wl_surface.setInputRegion(wl_region);
+    wl_surface.setOpaqueRegion(null);
+    try ctx.?.layer_marker.init(wl_surface, .layer_marker);
+    ctx.?.wl_surface = wl_surface;
+    wl_surface.commit();
+
     ctx.?.seats.init();
     ctx.?.outputs.init();
     ctx.?.windows.init();
@@ -157,6 +174,8 @@ pub fn deinit() void {
     if (ctx.?.rwm_input_manager) |rwm_input_manager| rwm_input_manager.destroy();
     if (ctx.?.rwm_libinput_config) |rwm_libinput_config| rwm_libinput_config.destroy();
     if (ctx.?.rwm_xkb_config) |rwm_xkb_config| rwm_xkb_config.destroy();
+    ctx.?.layer_marker.deinit();
+    ctx.?.wl_surface.destroy();
 
     // first destroy windows for it's destroy function may depends on others
     {
@@ -439,9 +458,10 @@ pub fn quit(self: *Self, exit_session: bool) void {
 }
 
 
-pub fn focus(self: *Self, window: *Window) void {
+pub fn focus(self: *Self, window: *Window, lift: bool) void {
     log.debug("<{*}> focus window: {*}", .{ self, window });
 
+    if (lift) self.window_to_lift = window;
     if (self.focus_stack.first() == window) return;
 
     if (window.output) |output| {
@@ -486,7 +506,7 @@ pub fn focus_iter(self: *Self, direction: types.Direction, skip: types.WindowIte
                     .floating => if (new_window.floating) continue,
                     .nonfloating => if (!new_window.floating) continue,
                 }
-                self.focus(new_window);
+                self.focus(new_window, true);
                 break;
             }
         }
@@ -580,7 +600,7 @@ pub fn swap(self: *Self, direction: types.Direction) void {
             if (new_window == window) break;
             if (new_window.is_visible_in(window.output.?) and !new_window.floating) {
                 window.link.swapWith(&new_window.link);
-                self.focus(window);
+                self.focus(window, true);
                 break;
             }
         }
@@ -923,6 +943,64 @@ fn prepare_manage(self: *Self) void {
 }
 
 
+fn prepare_render_windows(self: *Self) void {
+    const config = Config.get();
+
+    const focused = self.focused_window();
+
+    var it = self.windows.safeIterator(.forward);
+    while (it.next()) |window| {
+        if (!window.is_visible()) {
+            window.hide();
+        } else {
+            window.set_border(
+                if (window.fullscreen == .output) 0
+                else config.border.width,
+                if (!self.focus_exclusive() and window == focused)
+                    config.border.color.focus
+                else config.border.color.unfocus
+            );
+        }
+    }
+
+    if (focused) |window| {
+        // move focus to head of focus_stack
+        if (!window.sticky) self.focus(window, false);
+    }
+}
+
+fn render_windows(self: *Self) void {
+    {
+        var it = self.windows.safeIterator(.forward);
+        while (it.next()) |window| {
+            window.render();
+
+            if (!window.layer_managed) {
+                window.layer_managed = true;
+                if (window.floating) {
+                    window.place(.top);
+                } else {
+                    window.place(.{
+                        .below = self.layer_marker.rwm_shell_surface_node,
+                    });
+                }
+            }
+        }
+    }
+
+    if (self.window_to_lift) |window| {
+        self.window_to_lift = null;
+        if (window.floating) {
+            window.place(.top);
+        } else {
+            window.place(.{
+                .below = self.layer_marker.rwm_shell_surface_node,
+            });
+        }
+    }
+}
+
+
 fn rwm_listener(rwm: *river.WindowManagerV1, event: river.WindowManagerV1.Event, context: *Self) void {
     std.debug.assert(rwm == context.rwm);
 
@@ -977,52 +1055,8 @@ fn rwm_listener(rwm: *river.WindowManagerV1, event: river.WindowManagerV1.Event,
         .render_start => {
             log.debug("render start", .{});
 
-            const focused = context.focused_window();
-            var top_windows: std.ArrayList(*Window) = .empty;
-            defer top_windows.deinit(utils.allocator);
-
-            {
-                var it = context.focus_stack.safeIterator(.forward);
-                while (it.next()) |window| {
-                    if (!window.is_visible()) {
-                        window.hide();
-                    } else {
-                        window.set_border(
-                            if (window.fullscreen == .output) 0 else config.border.width,
-                            if (!context.focus_exclusive() and window == focused)
-                                config.border.color.focus
-                            else config.border.color.unfocus
-                        );
-                        if (window.floating) {
-                            top_windows.append(utils.allocator, window) catch |err| {
-                                log.warn("append floating window failed: {}", .{ err });
-                            };
-                        }
-                    }
-
-                    window.render();
-                }
-            }
-
-            if (focused) |window| {
-                // move focus to head of focus_stack
-                if (!window.sticky) context.focus(window);
-
-                (
-                    if (window.floating) top_windows.insert(utils.allocator, 0, window)
-                    else top_windows.append(utils.allocator, window)
-                ) catch |err| {
-                    log.warn("insert or append focused window failed: {}", .{ err });
-                    window.place(.top);
-                };
-            }
-
-            {
-                var i: i32 = @as(i32, @intCast(top_windows.items.len)) - 1;
-                while (i >= 0) : (i -= 1) {
-                    top_windows.items[@intCast(i)].place(.top);
-                }
-            }
+            context.prepare_render_windows();
+            context.render_windows();
 
             if (comptime build_options.background_enabled) {
                 var it = context.outputs.safeIterator(.forward);
@@ -1055,7 +1089,7 @@ fn rwm_listener(rwm: *river.WindowManagerV1, event: river.WindowManagerV1.Event,
                     else config.default_layout,
                 ),
             );
-            context.focus(window);
+            context.focus(window, true);
         },
         .output => |data| {
             log.debug("new output {*}", .{ data.id });

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -176,7 +176,7 @@ pub fn manage(self: *Self) void {
         // avoid cursor wrapping
         self.previous_focused = .{ .window = window };
 
-        context.focus(window);
+        context.focus(window, false);
     }
 
     self.handle_actions();
@@ -592,7 +592,7 @@ fn handle_actions(self: *Self) void {
             },
             .toggle_floating => {
                 if (context.focused_window()) |window| {
-                    window.toggle_floating();
+                    window.toggle_floating(null);
                 }
             },
             .toggle_sticky => {
@@ -613,7 +613,7 @@ fn handle_actions(self: *Self) void {
                         switch (output.current_layout()) {
                             .tile, .deck => {
                                 if (!data.swap) {
-                                    context.focus(window);
+                                    context.focus(window, true);
                                     context.shift_to_head(window);
                                     continue;
                                 }
@@ -623,8 +623,8 @@ fn handle_actions(self: *Self) void {
                                     else context.focused_before(window, true) orelse continue;
 
                                 // ensure the old master immediately behind the new master in focus_stack
-                                context.focus(master);
-                                context.focus(new_master);
+                                context.focus(master, true);
+                                context.focus(new_master, true);
 
                                 // swap old master with new master
                                 master.link.swapWith(&new_master.link);
@@ -645,6 +645,7 @@ fn handle_actions(self: *Self) void {
                                 context.focus(
                                     if (window != master) master
                                     else context.focused_before(window, true) orelse continue,
+                                    true,
                                 );
                             },
                             else => {}
@@ -756,7 +757,7 @@ fn window_interaction(self: *Self, window: *Window) void {
     // avoid cursor wrapping
     self.previous_focused = .{ .window = window };
 
-    context.focus(window);
+    context.focus(window, true);
 }
 
 
@@ -861,6 +862,7 @@ fn rwm_seat_listener(rwm_seat: *river.SeatV1, event: river.SeatV1.Event, seat: *
             log.debug("<{*}> interaction with {*}", .{ seat, shell_surface });
 
             switch (shell_surface.type) {
+                .layer_marker => unreachable,
                 .bar => |bar| if (comptime build_options.bar_enabled) {
                     log.debug("<{*}> interaction with {*}", .{ seat, bar });
 

--- a/src/kwm/shell_surface.zig
+++ b/src/kwm/shell_surface.zig
@@ -13,6 +13,7 @@ const types = @import("types.zig");
 const Context = @import("context.zig");
 
 const Type = union(enum) {
+    layer_marker,
     background: if (build_options.background_enabled) *@import("background.zig") else void,
     bar: if (build_options.bar_enabled) *@import("bar.zig") else void,
 };

--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -50,6 +50,7 @@ former_output: ?[]const u8 = null,
 
 unhandled_events: std.ArrayList(Event) = undefined,
 
+layer_managed: bool = false,
 fullscreen: union(enum) {
     none,
     window,
@@ -413,18 +414,17 @@ pub fn ensure_floating(self: *Self) void {
     if (self.output) |output| {
         if (output.current_layout() == .float) return;
     }
-    if (!self.floating) {
-        log.debug("<{*}> turning floating", .{ self });
-
-        self.floating = true;
-    }
+    self.toggle_floating(true);
 }
 
 
-pub fn toggle_floating(self: *Self) void {
-    log.debug("<{*}> toggle floating: {}", .{ self, !self.floating });
+pub fn toggle_floating(self: *Self, flag: ?bool) void {
+    self.floating =
+        if (flag) |floating| (if (self.floating != floating) floating else return)
+        else !self.floating;
+    self.layer_managed = false;
 
-    self.floating = !self.floating;
+    log.debug("<{*}> toggle floating: {}", .{ self, self.floating });
 
     if (comptime build_options.bar_enabled) {
         if (self.output) |output| {
@@ -821,7 +821,7 @@ fn swallow(self: *Self, window: *Self) void {
 
     self.swallowing = window;
 
-    self.floating = window.floating;
+    self.toggle_floating(window.floating);
     self.tag = window.tag;
     self.x = window.x;
     self.y = window.y;
@@ -878,7 +878,7 @@ fn apply_rule(self: *Self, rule: *const Config.WindowRule) void {
             }
         }
     }
-    if (rule.floating) |floating| self.floating = floating;
+    if (rule.floating) |floating| self.toggle_floating(floating);
     if (rule.dimension) |dimension| self.resize(dimension.width, dimension.height);
     if (rule.decoration) |decoration| self.decoration = decoration;
     if (rule.is_terminal) |is_terminal| self.is_terminal = is_terminal;
@@ -888,7 +888,7 @@ fn apply_rule(self: *Self, rule: *const Config.WindowRule) void {
         self.link.remove(); self.link.init();
         self.flink.remove(); self.flink.init();
         context.attach_window(self, mode);
-        context.focus(self);
+        context.focus(self, true);
     }
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -123,7 +123,7 @@ pub fn main() !void {
         const rwm_libinput_config = globals.rwm_libinput_config orelse return error.MissingRiverLibinputConfig;
         const rwm_xkb_config = globals.rwm_xkb_config orelse return error.MissingRiverXkbConfig;
 
-        kwm.init(
+        try kwm.init(
             registry,
             wl_compositor,
             wl_subcompositor,


### PR DESCRIPTION
- add a river_shell_surface as seperator between floating and nonfloating layer
- do not let sloppy focus lift the window to top

related: #121 