### PR TITLE
feat: support to preprocess config, allow host-specific configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ zig build -Doptimize=ReleaseSafe
   copied from `config.def.zon` if missing)
 - `-Dbackground`: enable or disable the solid background (defaults to `false`)
 - `-Dbar`: enable or disable the status bar (defaults to `true`)
+- `-Dpreprocess`: enable or disable config preprocessing (defaults to `false`)
 - `--prefix`: specify the path to install files
 
 ## Configuration

--- a/build.zig
+++ b/build.zig
@@ -67,28 +67,60 @@ pub fn build(b: *std.Build) void {
 
     const default_config_path = b.option([]const u8, "config", "path to config file") orelse "config.zon";
     const backup_default_config_path = "config.def.zon";
+    const config_path = blk: {
+        fs.cwd().access(default_config_path, .{}) catch |err| switch (err) {
+            error.FileNotFound => {
+                std.log.warn(
+                    "Config file `{s}` not found, creating from `{s}`",
+                    .{ default_config_path, backup_default_config_path },
+                );
+
+                fs.cwd().copyFile(backup_default_config_path, fs.cwd(), default_config_path, .{}) catch |copy_err| {
+                    std.log.err(
+                        "Failed to copy `{s}` to `{s}`: {}",
+                        .{ backup_default_config_path, default_config_path, copy_err },
+                    );
+                    break :blk b.path(backup_default_config_path);
+                };
+
+                std.log.info(
+                    "Config file `{s}` created successfully. Please review and customize it.",
+                    .{ default_config_path },
+                );
+            },
+            else => {
+                std.log.err(
+                    "Access config file `{s}` failed: {}, use `{s}`",
+                    .{ default_config_path, err, backup_default_config_path },
+                );
+                break :blk b.path(backup_default_config_path);
+            }
+        };
+        break :blk b.path(default_config_path);
+    };
+    const run_preprocess = b.option(bool, "preprocess", "if preprocess configuration file") orelse false;
     const default_config_mod = b.createModule(.{
         .target = target,
         .optimize = optimize,
-        .root_source_file = blk: {
-            fs.cwd().access(default_config_path, .{}) catch |err| switch (err) {
-                error.FileNotFound => {
-                    std.log.warn("Config file `{s}` not found, creating from `{s}`", .{ default_config_path, backup_default_config_path });
-
-                    fs.cwd().copyFile(backup_default_config_path, fs.cwd(), default_config_path, .{}) catch |copy_err| {
-                        std.log.err("Failed to copy `{s}` to `{s}`: {}", .{ backup_default_config_path, default_config_path, copy_err });
-                        break :blk b.path(backup_default_config_path);
-                    };
-
-                    std.log.info("Config file `{s}` created successfully. Please review and customize it.", .{default_config_path});
-                },
-                else => {
-                    std.log.err("access config file `{s}` failed: {}, use `{s}`", .{ default_config_path, err, backup_default_config_path });
-                    break :blk b.path(backup_default_config_path);
-                }
-            };
-            break :blk b.path(default_config_path);
-        },
+        .root_source_file = if (run_preprocess) blk: {
+            const preprocess = b.addExecutable(.{
+                .name = "preprocess",
+                .root_module = b.createModule(.{
+                    .root_source_file = b.path("src/preprocess_config.zig"),
+                    .target = target,
+                    .optimize = .ReleaseSafe,
+                    .imports = &.{
+                        .{ .name = "mvzr", .module = mvzr_mod },
+                    },
+                    .link_libc = true,
+                })
+            });
+            const preprocess_run = b.addRunArtifact(preprocess);
+            preprocess_run.addArg("-i");
+            preprocess_run.addFileArg(config_path);
+            preprocess_run.addArg("-o");
+            break :blk preprocess_run.addOutputFileArg("config.zon");
+        } else config_path,
     });
     const config_mod = b.createModule(.{
         .target = target,

--- a/src/config.zig
+++ b/src/config.zig
@@ -13,6 +13,7 @@ const kwm = @import("kwm");
 
 const rule = @import("config/rule.zig");
 const constants = @import("config/constants.zig");
+const preprocess = @import("config/preprocess.zig");
 pub const meta = @import("config/meta.zig");
 
 var allocator: mem.Allocator = undefined;
@@ -230,24 +231,17 @@ fn try_load_user_config() ?meta.make_fields_optional(Self) {
     };
     defer file.close();
 
-    const stat = file.stat() catch |err| {
-        log.err("stat file `{s}` failed: {}", .{ path, err });
+    var buffer = preprocess.preprocess(allocator, file) catch |err| {
+        log.err("preprocess `{s}` failed: {}", .{ path, err });
         return null;
     };
-    const buffer = allocator.alloc(u8, stat.size+1) catch |err| {
-        log.err("alloc {} byte failed: {}", .{ stat.size+1, err });
-        return null;
-    };
-    defer allocator.free(buffer);
-
-    _ = file.readAll(buffer) catch return null;
-    buffer[stat.size] = 0;
+    defer buffer.deinit(allocator);
 
     @setEvalBranchQuota(20000);
     return zon.parse.fromSlice(
         meta.make_fields_optional(Self),
         allocator,
-        buffer[0..stat.size:0],
+        buffer.items[0..buffer.items.len-1:0],
         null,
         .{.ignore_unknown_fields = true},
     ) catch |err| {

--- a/src/config/preprocess.zig
+++ b/src/config/preprocess.zig
@@ -1,0 +1,130 @@
+const std = @import("std");
+const fs = std.fs;
+const mem = std.mem;
+const posix = std.posix;
+const log = std.log.scoped(.preprocess);
+
+const mvzr = @import("mvzr");
+
+const State = union(enum) {
+    normal,
+    @"if",
+    @"else",
+    elif,
+};
+const Target = struct {
+    hostname: []const u8,
+};
+
+
+pub fn preprocess(allocator: mem.Allocator, file: fs.File) !std.ArrayList(u8) {
+    var result: std.ArrayList(u8) = .empty;
+    errdefer result.deinit(allocator);
+
+    var reader_buffer: [1024]u8 = undefined;
+    var reader = file.reader(&reader_buffer);
+    const f = &reader.interface;
+
+    var hostname_buffer: [posix.HOST_NAME_MAX]u8 = undefined;
+    const target: Target = .{
+        .hostname = try posix.gethostname(&hostname_buffer),
+    };
+
+    const if_pattern = mvzr.compile(
+        \\//\s*@if\s*\(.*\)
+        \\
+    ).?;
+    const elif_pattern = mvzr.compile(
+        \\//\s*@elif\s*\(.*\)
+        \\
+    ).?;
+    const else_pattern = mvzr.compile(
+        \\//\s*@else
+        \\
+    ).?;
+    const end_pattern = mvzr.compile(
+        \\//\s*@endif
+        \\
+    ).?;
+    var save = true;
+    var matched = false;
+    var state: State = .normal;
+    while (f.takeDelimiterInclusive('\n')) |line| {
+        switch (state) {
+            .normal => {
+                if (if_pattern.isMatch(line)) {
+                    matched = (try match(line, &target)) orelse continue;
+                    save = matched;
+                    state = .@"if";
+                    continue;
+                }
+            },
+            .@"if", .elif => {
+                if (end_pattern.isMatch(line)) {
+                    save = true;
+                    matched = false;
+                    state = .normal;
+                    continue;
+                } else if (else_pattern.isMatch(line)) {
+                    save = !matched;
+                    state = .@"else";
+                    continue;
+                } else if (elif_pattern.isMatch(line)) {
+                    if (matched) {
+                        save = false;
+                    } else {
+                        matched = (try match(line, &target)) orelse continue;
+                        save = matched;
+                    }
+                    state = .elif;
+                    continue;
+                }
+            },
+            .@"else" => {
+                if (end_pattern.isMatch(line)) {
+                    save = true;
+                    matched = false;
+                    state = .normal;
+                    continue;
+                }
+            },
+        }
+
+        if (save) {
+            try result.appendSlice(allocator, line);
+        }
+    } else |err| if (err != error.EndOfStream) return err;
+
+    try result.append(allocator, 0);
+    return result;
+}
+
+
+fn match(line: []const u8, target: *const Target) !?bool {
+    inline for (@typeInfo(Target).@"struct".fields) |field_info| {
+        const str = parse(line, field_info.name) orelse return null;
+        const pattern = mvzr.compile(str) orelse return error.CompileFailed;
+
+        log.debug(field_info.name ++ ": try match {s} with {s}", .{ @field(target, field_info.name), str });
+
+        if (!pattern.isMatch(@field(target, field_info.name))) return false;
+    }
+    return true;
+}
+
+
+fn parse(line: []const u8, name: []const u8) ?[]const u8 {
+    var i = mem.indexOf(u8, line, name) orelse return null;
+    i += name.len;
+    const end = line.len - 2;
+
+    while (i < end and line[i] == ' ') : (i += 1) {}
+    if (line[i] != '=') return null;
+    i += 1;
+
+    while (i < end and line[i] == ' ') : (i += 1) {}
+    const start = i;
+
+    while (i < end and line[i] != ',') : (i += 1) {}
+    return line[start..i];
+}

--- a/src/preprocess_config.zig
+++ b/src/preprocess_config.zig
@@ -1,0 +1,39 @@
+const std = @import("std");
+const fs = std.fs;
+const mem = std.mem;
+const heap = std.heap;
+const process = std.process;
+
+const preprocess = @import("config/preprocess.zig");
+
+
+pub fn main() !void {
+    var input: ?[]const u8 = null;
+    var output: ?[]const u8 = null;
+    var args = process.args();
+    while (args.next()) |arg| {
+        if (mem.eql(u8, arg, "-i")) {
+            input = args.next();
+        } else if (mem.eql(u8, arg, "-o")) {
+            output = args.next();
+        }
+    }
+
+    const input_file = try fs.cwd().openFile(
+        input orelse return error.MissingInput,
+        .{ .mode = .read_only },
+    );
+    defer input_file.close();
+
+    const output_file = try fs.createFileAbsolute(output orelse return error.MissingOutput, .{});
+    defer output_file.close();
+
+    var buffer = try preprocess.preprocess(heap.c_allocator, input_file);
+    defer buffer.deinit(heap.c_allocator);
+
+    var output_buffer: [4096]u8 = undefined;
+    var output_writer = output_file.writer(&output_buffer);
+    const writer = &output_writer.interface;
+    try writer.writeAll(buffer.items[0..buffer.items.len-1:0]);
+    try writer.flush();
+}


### PR DESCRIPTION
support syntax like below in `config.zon`:
```zon
// @if(hostname=...)
...
// @elif(hostname=...)
...
// @else
...
// @endif
```
`kwm` will try to match specify hostname before loading config. If not matched, will ignore the text of the block. related: #119 