### PR TITLE
feat(config): support override default bindings

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -6,6 +6,8 @@ const mem = std.mem;
 const zon = std.zon;
 const log = std.log.scoped(.config);
 
+const xkbcommon = @import("xkbcommon");
+const Keysym = xkbcommon.Keysym;
 const wayland = @import("wayland");
 const river = wayland.client.river;
 
@@ -22,6 +24,23 @@ var config: ?Self = null;
 var user_config: ?meta.make_fields_optional(Self) = null;
 const default_config: Self = @import("default_config");
 
+const BindingType = enum {
+    key,
+    pointer,
+};
+const KeyBindingID = struct {
+    mode: []const u8,
+    modifiers: u32,
+    keysym: u32,
+};
+const PointerBindingID = struct {
+    mode: []const u8,
+    modifiers: u32,
+    button: u32,
+};
+var key_binding_list: std.ArrayList(@TypeOf(default_config.bindings.key[0])) = .empty;
+var pointer_binding_list: std.ArrayList(@TypeOf(default_config.bindings.pointer[0])) = .empty;
+
 pub const lock_mode = constants.lock_mode;
 pub const default_mode = constants.default_mode;
 pub const WindowRule = rule.Window;
@@ -29,6 +48,25 @@ pub const OutputRule = rule.Output;
 pub const InputDeviceRule = rule.InputDevice;
 pub const LibinputDeviceRule = rule.LibinputDevice;
 pub const XkbKeyboardRule = rule.XkbKeyboard;
+
+
+fn binding_context(comptime @"type": BindingType) type {
+    const T, const name = switch (@"type") {
+        .key => .{ KeyBindingID, "keysym" },
+        .pointer => .{ PointerBindingID, "button" },
+    };
+    return struct {
+        pub fn hash(self: @This(), binding: T) u64 {
+            _ = self;
+            return std.hash_map.hashString(binding.mode) ^ binding.modifiers ^ @field(binding, name);
+        }
+
+        pub fn eql(self: @This(), a: T, b: T) bool {
+            _ = self;
+            return @field(a, name) == @field(b, name) and a.modifiers == b.modifiers and mem.eql(u8, a.mode, b.mode);
+        }
+    };
+}
 
 
 env: []const struct { []const u8, []const u8 },
@@ -132,13 +170,13 @@ bindings: struct {
         mode: []const u8 = default_mode,
         keysym: []const u8,
         modifiers: river.SeatV1.Modifiers,
-        event: kwm.XkbBindingEvent,
+        event: ?kwm.XkbBindingEvent,
     },
     pointer: []const struct {
         mode: []const u8 = default_mode,
         button: kwm.Button,
         modifiers: river.SeatV1.Modifiers,
-        event: kwm.PointerBindingEvent,
+        event: ?kwm.PointerBindingEvent,
     }
 },
 
@@ -166,6 +204,8 @@ pub inline fn deinit() void {
     if (user_config) |cfg| {
         log.debug("free user config", .{});
 
+        key_binding_list.deinit(allocator);
+        pointer_binding_list.deinit(allocator);
         meta.zon_free(allocator, cfg);
     }
 }
@@ -262,6 +302,55 @@ fn refresh_config() void {
 
     if (user_config) |cfg| {
         config = meta.override(default_config, cfg);
+
+        if (cfg.bindings) |bindings| {
+            inline for(&[_]BindingType { .key, .pointer }) |t| {
+                const T, const name, const list = switch (comptime t) {
+                    .key => .{ KeyBindingID, "keysym", &key_binding_list },
+                    .pointer => .{ PointerBindingID, "button", &pointer_binding_list },
+                };
+                var set: std.HashMap(
+                    T,
+                    void,
+                    binding_context(t),
+                    std.hash_map.default_max_load_percentage,
+                ) = .init(allocator);
+                defer set.deinit();
+
+                if (@field(bindings, @tagName(t))) |arr| {
+                    if (@field(default_config.bindings, @tagName(t)).len > 0) {
+                        list.clearRetainingCapacity();
+                        for (arr) |binding| {
+                            var id: T = undefined;
+                            id.mode = binding.mode;
+                            id.modifiers = @bitCast(binding.modifiers);
+                            @field(id, name) = switch (comptime t) {
+                                .key => keysym_from_name(@field(binding, name)) orelse continue,
+                                .pointer => @intFromEnum(@field(binding, name)),
+                            };
+                            if (set.contains(id)) continue;
+
+                            list.append(allocator, binding) catch continue;
+                            set.put(id, {}) catch continue;
+                        }
+                        for (@field(default_config.bindings, @tagName(t))) |binding| {
+                            var id: T = undefined;
+                            id.mode = binding.mode;
+                            id.modifiers = @bitCast(binding.modifiers);
+                            @field(id, name) = switch (comptime t) {
+                                .key => keysym_from_name(@field(binding, name)) orelse continue,
+                                .pointer => @intFromEnum(@field(binding, name)),
+                            };
+                            if (set.contains(id)) continue;
+
+                            list.append(allocator, binding) catch continue;
+                            set.put(id, {}) catch continue;
+                        }
+                        @field(config.?.bindings, @tagName(t)) = list.items;
+                    }
+                }
+            }
+        }
         log.debug("config: {any}", .{ config.? });
     }
 }
@@ -281,4 +370,33 @@ pub fn get_mode_tag(self: *const Self, mode: []const u8) ?[]const u8 {
         if (mem.eql(u8, m, mode)) return t;
     }
     return null;
+}
+
+
+// https://codeberg.org/river/river-classic/src/commit/f0908e2d117ede7114fa85c65622b055c565c250/river/command/map.zig#L254
+pub fn keysym_from_name(name: []const u8) ?u32 {
+    const n = allocator.dupeZ(u8, name) catch |err| {
+        log.err("dupeZ failed while call keysym_from_name: {}", .{ err });
+        return null;
+    };
+    defer allocator.free(n);
+
+    const keysym = Keysym.fromName(n, .case_insensitive);
+    if (keysym == .NoSymbol) {
+        log.err("invalid keysym `{s}`", .{ name });
+        return null;
+    }
+
+    if (@intFromEnum(keysym) == Keysym.XF86Screensaver) {
+        if (mem.eql(u8, name, "XF86Screensaver")) {
+            //
+        } else if (mem.eql(u8, name, "XF86ScreenSaver")) {
+            return Keysym.XF86ScreenSaver;
+        } else {
+            log.err("ambiguous keysym name '{s}'", .{ name });
+            return null;
+        }
+    }
+
+    return @intFromEnum(keysym);
 }

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -310,6 +310,8 @@ pub fn create_bindings(self: *Self) void {
     const config = Config.get();
 
     for (config.bindings.key) |key_binding| {
+        if (key_binding.event == null) continue;
+
         if (!self.xkb_bindings.contains(key_binding.mode)) {
             self.xkb_bindings.put(key_binding.mode, .empty) catch |err| {
                 log.err("<{*}> put a new xkb binding list failed: {}", .{ self, err });
@@ -322,12 +324,12 @@ pub fn create_bindings(self: *Self) void {
             utils.allocator,
             binding.XkbBinding.create(
                 self,
-                keysym_from_name(key_binding.keysym) orelse {
+                Config.keysym_from_name(key_binding.keysym) orelse {
                     log.warn("ambiguous keysym name '{s}'", .{ key_binding.keysym });
                     continue;
                 },
                 key_binding.modifiers,
-                key_binding.event,
+                key_binding.event.?,
             ) catch |err| {
                 log.err("<{*}> create xkb binding failed: {}", .{ self, err });
                 continue;
@@ -349,12 +351,14 @@ pub fn create_bindings(self: *Self) void {
                 key_binding.modifiers.mod3,
                 key_binding.modifiers.mod4,
                 key_binding.modifiers.mod5,
-                key_binding.event,
+                key_binding.event.?,
             },
         );
     }
 
     for (config.bindings.pointer) |pointer_binding| {
+        if (pointer_binding.event == null) continue;
+
         if (!self.pointer_bindings.contains(pointer_binding.mode)) {
             self.pointer_bindings.put(pointer_binding.mode, .empty) catch |err| {
                 log.err("<{*}> put a new pointer binding list failed: {}", .{ self, err });
@@ -369,7 +373,7 @@ pub fn create_bindings(self: *Self) void {
                 self,
                 @intFromEnum(pointer_binding.button),
                 pointer_binding.modifiers,
-                pointer_binding.event,
+                pointer_binding.event.?,
             ) catch |err| {
                 log.err("<{*}> create pointer binding failed: {}", .{ self, err });
                 continue;
@@ -391,7 +395,7 @@ pub fn create_bindings(self: *Self) void {
                 pointer_binding.modifiers.mod3,
                 pointer_binding.modifiers.mod4,
                 pointer_binding.modifiers.mod5,
-                pointer_binding.event,
+                pointer_binding.event.?,
             },
         );
     }
@@ -967,33 +971,4 @@ fn wl_pointer_listener(wl_pointer: *wl.Pointer, event: wl.Pointer.Event, seat: *
         },
         else => {}
     }
-}
-
-
-// https://codeberg.org/river/river-classic/src/commit/f0908e2d117ede7114fa85c65622b055c565c250/river/command/map.zig#L254
-fn keysym_from_name(name: []const u8) ?u32 {
-    const n = utils.allocator.dupeZ(u8, name) catch |err| {
-        log.err("dupeZ failed while call keysym_from_name: {}", .{ err });
-        return null;
-    };
-    defer utils.allocator.free(n);
-
-    const keysym = Keysym.fromName(n, .case_insensitive);
-    if (keysym == .NoSymbol) {
-        log.err("invalid keysym `{s}`", .{ name });
-        return null;
-    }
-
-    if (@intFromEnum(keysym) == Keysym.XF86Screensaver) {
-        if (mem.eql(u8, name, "XF86Screensaver")) {
-            //
-        } else if (mem.eql(u8, name, "XF86ScreenSaver")) {
-            return Keysym.XF86ScreenSaver;
-        } else {
-            log.err("ambiguous keysym name '{s}'", .{ name });
-            return null;
-        }
-    }
-
-    return @intFromEnum(keysym);
 }


### PR DESCRIPTION
Previously, bindings in the user configuration file would overwrite all default bindings; now, they will only overwrite bindings for the same key. And you could set event to null to disable default bindings. However, I don't find it user-friendly, and I might not merge it. Maybe others might prefer it.