### PR TITLE
Fix: make sure child window is centered on the output

### DIFF
--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -932,7 +932,15 @@ fn rwm_window_listener(rwm_window: *river.WindowV1, event: river.WindowV1.Event,
                 if (window.output == null) {
                     window.unbound_resize(data.width, data.height);
                 } else {
+                    const old_width = window.width;
+                    const old_height = window.height;
+
                     window.resize(data.width, data.height);
+
+                    if (window.floating and !window.position_undefined and
+                        (old_width != window.width or old_height != window.height)) {
+                        window.center();
+                    }
                 }
             }
         },
@@ -959,6 +967,10 @@ fn rwm_window_listener(rwm_window: *river.WindowV1, event: river.WindowV1.Event,
 
                 window.toggle_floating(true);
                 window.position_undefined = true;
+
+                if (window.output != null and window.width > 0 and window.height > 0 ) {
+                    window.center();
+                }
             }
         },
         .fullscreen_requested => |data| {


### PR DESCRIPTION
This fixes the second problem described in https://github.com/kewuaa/kwm/pull/132#issuecomment-4131625560.

For the reposition and flickering, maybe we can hide the window until it is decided to be a floating child window or not?