### PR TITLE
Mod: bar mode visual improvements

### DIFF
--- a/src/kwm/bar.zig
+++ b/src/kwm/bar.zig
@@ -558,7 +558,7 @@ fn render_dynamic_component(self: *Self) void {
             .height = h,
         },
     };
-    _ = pixman.Image.fillRectangles(.src, buffer.image, &transparent, 1, &bg_rect);
+    _ = pixman.Image.fillRectangles(.src, buffer.image, &select_bg, 1, &bg_rect);
 
 
     var x: i16 = 0;
@@ -569,12 +569,16 @@ fn render_dynamic_component(self: *Self) void {
         x += self.render_str(
             buffer,
             mode_tag,
-            &normal_fg,
+            &select_fg,
             x+@as(i16, @intCast(@divFloor(pad, 2))),
             y,
         ) + @as(i16, @intCast(pad));
     }
     self.dynamic_splits.appendBounded(x) catch unreachable;
+
+    bg_rect[0].x = x;
+    bg_rect[0].width = w - @as(u16, @intCast(x));
+    _ = pixman.Image.fillRectangles(.src, buffer.image, &transparent, 1, &bg_rect);
 
     x += self.render_str(
         buffer,


### PR DESCRIPTION
- Add more contrast to mode indicator
- Render mode before layout, inorder to separate mode and title, because they would have same background color.

Matches the river-classic's [dam](https://codeberg.org/sewn/dam) bar and dwl's [bar-modes](https://codeberg.org/dwl/dwl-patches/src/branch/main/patches/bar-modes) patch.

I feel current rendering is hard to read in some situations:

| version | screenshot |
| --- | --- |
| N/A | <img width="640" height="19" alt="a" src="https://github.com/user-attachments/assets/be28f330-c783-40ad-85b8-95e1abef4bae" /> |
| old  | <img width="640" height="19" alt="e" src="https://github.com/user-attachments/assets/655e8114-9f69-487b-bb9e-09568164365e" /> |
| new | <img width="640" height="19" alt="c" src="https://github.com/user-attachments/assets/d455cae4-855f-4a0f-a492-f02ea619b218" /> |
| old | <img width="640" height="19" alt="d" src="https://github.com/user-attachments/assets/214141c7-667c-4644-8999-ef03b7e86a58" /> |
| new | <img width="640" height="19" alt="b" src="https://github.com/user-attachments/assets/492f4454-144a-488c-aaa5-e909e96c6208" /> |
