### PR TITLE
Add set_window_tag_follow command to change tag when moving a window

### DIFF
--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -103,6 +103,7 @@ pub const Action = union(enum) {
     },
     set_output_tag: struct { tag: Tag },
     set_window_tag: struct { tag: Tag },
+    set_window_tag_follow: struct { tag: Tag },
     toggle_output_tag: struct { mask: u32 },
     toggle_window_tag: struct { mask: u32 },
     switch_to_previous_tag,

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -594,6 +594,11 @@ fn handle_actions(self: *Self) void {
                     window.set_tag(data.tag.of(.{ .window = window }));
                 }
             },
+            .set_window_tag_follow => |data| {
+                if (context.focused_window()) |window| {
+                    window.set_tag_follow(data.tag.of(.{ .window = window }));
+                }
+            },
             .toggle_output_tag => |data| {
                 if (context.current_output) |output| {
                     output.toggle_tag(data.mask);

--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -241,6 +241,12 @@ pub fn set_tag(self: *Self, tag: u32) void {
 }
 
 
+pub fn set_tag_follow(self: *Self, tag: u32) void {
+    self.set_tag(tag);
+    if (self.output) |output| output.set_tag(tag);
+}
+
+
 pub fn toggle_tag(self: *Self, mask: u32) void {
     if (self.tag ^ mask == 0) return;
 


### PR DESCRIPTION
Most of the time this is unnecessary because you could just group `.set_window_tag` and `.set_output_tag`.

But that won't work when changing to an unoccupied tag, because it becomes occupied when the window is moved to it.