### PR TITLE
Expose option to always float to config

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -670,7 +670,7 @@
                 .modifiers = .{ .mod4 = true },
                 .event = .{
                     .click = .{
-                        .pressed = .toggle_floating,
+                        .pressed = .{ .toggle_floating = .{ .always_float = false } },
                     },
                 },
             },

--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -120,7 +120,7 @@ pub const Action = union(enum) {
     toggle_output_tag: struct { mask: u32 },
     toggle_window_tag: struct { mask: u32 },
     switch_to_previous_tag,
-    toggle_floating,
+    toggle_floating: struct { always_float: bool = false },
     toggle_sticky,
     toggle_swallow,
     zoom: struct { swap: bool },

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -622,9 +622,9 @@ fn handle_actions(self: *Self) void {
                     output.switch_to_previous_tag();
                 }
             },
-            .toggle_floating => {
+            .toggle_floating => |data| {
                 if (context.focused_window()) |window| {
-                    window.toggle_floating(null);
+                    window.toggle_floating(data.always_float);
                 }
             },
             .toggle_sticky => {


### PR DESCRIPTION
Use case:
```
.group = .{
    .actions = .{
        .{ .toggle_floating = .{ .always_float = true } },
        .pointer_move
    },
},
```
```
.group = .{
    .actions = .{
        .{ .toggle_floating = .{ .always_float = true } },
        .pointer_resize
    },
},
```

Unless you are planning on allowing tiled windows to be moved/resized by mouse drags, perhaps these could make sense as default mouse pointer bindings?