### PR TITLE
Output detailed diagnostics when config parse fails

### DIFF
--- a/src/config.zig
+++ b/src/config.zig
@@ -168,14 +168,18 @@ fn try_load_user_config() ?Config {
     defer buffer.deinit(allocator);
 
     @setEvalBranchQuota(20000);
+    var diag: std.zon.parse.Diagnostics = .{};
     return zon.parse.fromSlice(
         Config,
         allocator,
         buffer.items[0..buffer.items.len-1:0],
-        null,
+        &diag,
         .{.ignore_unknown_fields = true},
     ) catch |err| {
-        log.err("load user config failed: {}", .{ err });
+        switch (err) {
+            error.ParseZon => log.err("load user config failed: {f}", .{ diag }),
+            else => log.err("load user config failed: {}", .{ err }),
+        }
         return null;
     };
 }


### PR DESCRIPTION
Right now if the config parse fails, the log output doesn't help you figure out why:
```sh
error(config): load user config failed: error.ParseZon
```

This change displays the diagnostics provided by the standard library to make tracking down the mistake easier. You now get errors like this instead:
```sh
error(config): load user config failed: 3:15: error: expected ',' after initializer
```
```sh
error(config): load user config failed: 4:14: error: missing required field keysym
```