### PR TITLE
Unblock SIGCHLD during child process spawning

### DIFF
--- a/src/kwm/context.zig
+++ b/src/kwm/context.zig
@@ -801,6 +801,13 @@ pub fn spawn(self: *Self, argv: []const []const u8) ?process.Child {
         .home => self.env.get("HOME"),
         .custom => |dir| dir,
     };
+
+    var mask = posix.sigemptyset();
+    posix.sigaddset(&mask, posix.SIG.CHLD);
+    posix.sigprocmask(posix.SIG.UNBLOCK, &mask, null);
+
+    defer posix.sigprocmask(posix.SIG.BLOCK, &mask, null);
+
     child.spawn() catch |err| {
         log.err("spawn failed: {}", .{ err });
         return null;


### PR DESCRIPTION
Fixes: #203 
Currently exiting a shell spawned by the spawn command keeps the terminal window open. This is caused by the blocking of SIGCHLD.

Because the fork keeps the mask as described in signal(7)

> A child created via fork(2) inherits a copy of its parent's signal
> mask; the signal mask is preserved across execve(2).

the forked child (eg. the Terminal emulator) has the SIGCHLD blocked. When the shell exits the terminal does not get the Signal and thus stays open.

It works but I am not good enough at zig to say this is the correct implementation.