### PR TITLE
doc: update repology URL for packaging status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,8 +70,8 @@ zig build -Doptimize=ReleaseSafe
 
 ## Installation
 
-<a href="https://repology.org/project/kwm/versions">
-  <img align="right" width="192" src="https://repology.org/badge/vertical-allrepos/kwm.svg">
+<a href="https://repology.org/project/kwm-window-manager/versions">
+  <img align="right" width="192" src="https://repology.org/badge/vertical-allrepos/kwm-window-manager.svg">
 </a>
 
 See [packages.md] for community maintained packages.


### PR DESCRIPTION
Project is renamed to kwm-window-manager in repology due to conflicts in https://github.com/kewuaa/kwm/issues/202.