### PR TITLE
feat(output): per tag layout state

### DIFF
--- a/src/kwm/layout/deck.zig
+++ b/src/kwm/layout/deck.zig
@@ -20,6 +20,7 @@ pub fn arrange(self: *const Self, output: *Output) void {
     log.debug("<{*}> arrange windows in output {*}", .{ self, output });
 
     const context = Context.get();
+    const state = output.get_current_per_tag_state();
 
     const master = blk: {
         var it = context.windows.safeIterator(.forward);
@@ -31,10 +32,10 @@ pub fn arrange(self: *const Self, output: *Output) void {
         return;
     };
 
-    const w = output.exclusive_width() - 2 * self.outer_gap;
-    const h = output.exclusive_height() - 2 * self.outer_gap;
+    const w = output.exclusive_width() - 2 * state.deck_outer_gap;
+    const h = output.exclusive_height() - 2 * state.deck_outer_gap;
 
-    master.unbound_move(self.outer_gap, self.outer_gap);
+    master.unbound_move(state.deck_outer_gap, state.deck_outer_gap);
     master.unbound_resize(w, h);
 
     // find top stack window in context.focus_stack
@@ -48,55 +49,55 @@ pub fn arrange(self: *const Self, output: *Output) void {
             if (!found_stack_top) {
                 found_stack_top = true;
 
-                const master_size = switch (self.master_location) {
+                const master_size = switch (state.deck_master_location) {
                     .left, .right => @divFloor(w, 2),
                     .top, .bottom => @divFloor(h, 2),
                 };
 
-                const stack_size = switch (self.master_location) {
-                    .left, .right => w - master_size - self.inner_gap,
-                    .top, .bottom => h - master_size - self.inner_gap,
+                const stack_size = switch (state.deck_master_location) {
+                    .left, .right => w - master_size - state.deck_inner_gap,
+                    .top, .bottom => h - master_size - state.deck_inner_gap,
                 };
 
-                switch (self.master_location) {
+                switch (state.deck_master_location) {
                     .left => {
-                        master.unbound_move(self.outer_gap, self.outer_gap);
+                        master.unbound_move(state.deck_outer_gap, state.deck_outer_gap);
                         master.unbound_resize(master_size, h);
 
                         window.unbound_move(
-                            self.outer_gap + master_size + self.inner_gap,
-                            self.outer_gap,
+                            state.deck_outer_gap + master_size + state.deck_inner_gap,
+                            state.deck_outer_gap,
                         );
                         window.unbound_resize(stack_size, h);
                     },
                     .right => {
                         master.unbound_move(
-                            self.outer_gap + stack_size + self.inner_gap,
-                            self.outer_gap,
+                            state.deck_outer_gap + stack_size + state.deck_inner_gap,
+                            state.deck_outer_gap,
                         );
                         master.unbound_resize(master_size, h);
 
-                        window.unbound_move(self.outer_gap, self.outer_gap);
+                        window.unbound_move(state.deck_outer_gap, state.deck_outer_gap);
                         window.unbound_resize(stack_size, h);
                     },
                     .top => {
-                        master.unbound_move(self.outer_gap, self.outer_gap);
+                        master.unbound_move(state.deck_outer_gap, state.deck_outer_gap);
                         master.unbound_resize(w, master_size);
 
                         window.unbound_move(
-                            self.outer_gap,
-                            self.outer_gap + master_size + self.inner_gap,
+                            state.deck_outer_gap,
+                            state.deck_outer_gap + master_size + state.deck_inner_gap,
                         );
                         window.unbound_resize(w, stack_size);
                     },
                     .bottom => {
                         master.unbound_move(
-                            self.outer_gap,
-                            self.outer_gap + stack_size + self.inner_gap,
+                            state.deck_outer_gap,
+                            state.deck_outer_gap + stack_size + state.deck_inner_gap,
                         );
                         master.unbound_resize(w, master_size);
 
-                        window.unbound_move(self.outer_gap, self.outer_gap);
+                        window.unbound_move(state.deck_outer_gap, state.deck_outer_gap);
                         window.unbound_resize(w, stack_size);
                     }
                 }

--- a/src/kwm/layout/grid.zig
+++ b/src/kwm/layout/grid.zig
@@ -23,6 +23,7 @@ pub fn arrange(self: *const Self, output: *Output) void {
     log.debug("<{*}> arrange windows in output {*}", .{ self, output });
 
     const context = Context.get();
+    const state = output.get_current_per_tag_state();
 
     var windows: std.ArrayList(*Window) = .empty;
     defer windows.deinit(utils.allocator);
@@ -45,9 +46,9 @@ pub fn arrange(self: *const Self, output: *Output) void {
     const col_num: i32 = @intFromFloat(@ceil(@sqrt(@as(f64, @floatFromInt(windows.items.len)))));
     const row_num: i32 = @intFromFloat(@ceil(@as(f32, @floatFromInt(windows.items.len)) / @as(f32, @floatFromInt(col_num))));
     const available_width, const available_height = blk: {
-        const width = @max(0, output.exclusive_width() - 2*self.outer_gap);
-        const height = @max(0, output.exclusive_height() - 2*self.outer_gap);
-        break :blk switch (self.direction) {
+        const width = @max(0, output.exclusive_width() - 2*state.grid_outer_gap);
+        const height = @max(0, output.exclusive_height() - 2*state.grid_outer_gap);
+        break :blk switch (state.grid_direction) {
             .horizontal => .{ width, height },
             .vertical => .{ height, width },
         };
@@ -65,17 +66,17 @@ pub fn arrange(self: *const Self, output: *Output) void {
         const col: i32 = @as(i32, @intCast(i)) - row*col_num;
 
         const x = col * width + (if (col > 0) width_remain else 0) + if (row == row_num-1) last_row_pad else 0;
-        const y = row * height + if (row > 0) self.inner_gap+height_remain else 0;
-        const w = width - (if (col < col_num-1) self.inner_gap else 0) + if (col == 0) width_remain else 0;
-        const h = height - (if (row > 0) self.inner_gap else 0) + if (row == 0) height_remain else 0;
+        const y = row * height + if (row > 0) state.grid_inner_gap+height_remain else 0;
+        const w = width - (if (col < col_num-1) state.grid_inner_gap else 0) + if (col == 0) width_remain else 0;
+        const h = height - (if (row > 0) state.grid_inner_gap else 0) + if (row == 0) height_remain else 0;
 
-        switch (self.direction) {
+        switch (state.grid_direction) {
             .horizontal => {
-                window.unbound_move(x+self.outer_gap, y+self.outer_gap);
+                window.unbound_move(x+state.grid_outer_gap, y+state.grid_outer_gap);
                 window.unbound_resize(w, h);
             },
             .vertical => {
-                window.unbound_move(y+self.outer_gap, x+self.outer_gap);
+                window.unbound_move(y+state.grid_outer_gap, x+state.grid_outer_gap);
                 window.unbound_resize(h, w);
             },
         }

--- a/src/kwm/layout/monocle.zig
+++ b/src/kwm/layout/monocle.zig
@@ -14,16 +14,17 @@ pub fn arrange(self: *const Self, output: *Output) void {
     log.debug("<{*}> arrange windows in output {*}", .{ self, output });
 
     const context = Context.get();
+    const state = output.get_current_per_tag_state();
 
     const focus_top = context.focus_top_in(output, true) orelse return;
-    const available_width = output.exclusive_width() - 2*self.gap;
-    const available_height = output.exclusive_height() - 2*self.gap;
+    const available_width = output.exclusive_width() - 2*state.monocle_gap;
+    const available_height = output.exclusive_height() - 2*state.monocle_gap;
     {
         var it = context.windows.safeIterator(.forward);
         while (it.next()) |window| {
             if (!window.is_visible_in(output) or window.floating) continue;
             if (window != focus_top) window.hide();
-            window.unbound_move(self.gap, self.gap);
+            window.unbound_move(state.monocle_gap, state.monocle_gap);
             window.unbound_resize(available_width, available_height);
         }
     }

--- a/src/kwm/layout/scroller.zig
+++ b/src/kwm/layout/scroller.zig
@@ -17,6 +17,7 @@ pub fn arrange(self: *const Self, output: *Output) void {
     log.debug("<{*}> arrange windows in output {*}", .{ self, output });
 
     const context = Context.get();
+    const state = output.get_current_per_tag_state();
 
     const focus_top = context.focus_top_in(output, true) orelse return;
 
@@ -26,24 +27,24 @@ pub fn arrange(self: *const Self, output: *Output) void {
     const master_width: i32 = @intFromFloat(
         @as(f32, @floatFromInt(available_width)) * focus_top.scroller_mfact
     );
-    const height = available_height - 2*self.outer_gap;
-    const y = self.outer_gap;
+    const height = available_height - 2*state.scroller_outer_gap;
+    const y = state.scroller_outer_gap;
 
-    const left = @max(self.outer_gap, blk: {
+    const left = @max(state.scroller_outer_gap, blk: {
         var link = &focus_top.link;
         while (link.prev.? != &context.windows.link) {
             defer link = link.prev.?;
             const window: *Window = @fieldParentPtr("link", link.prev.?);
             if (window.is_visible_in(output) and !window.floating) {
-                break :blk switch (window.scroller_x orelse break :blk self.outer_gap) {
+                break :blk switch (window.scroller_x orelse break :blk state.scroller_outer_gap) {
                     .x => |x| x,
                     .center => window.x,
-                } + window.width + self.inner_gap;
+                } + window.width + state.scroller_inner_gap;
             }
         }
-        break :blk self.outer_gap;
+        break :blk state.scroller_outer_gap;
     });
-    const right = output.width - self.outer_gap - master_width;
+    const right = output.width - state.scroller_outer_gap - master_width;
     const master_x = blk: {
         const x = if (focus_top.scroller_x) |scroller_x| switch (scroller_x) {
             .x => |x| x,
@@ -66,7 +67,7 @@ pub fn arrange(self: *const Self, output: *Output) void {
             const window: *Window = @fieldParentPtr("link", link.prev.?);
             if (!window.is_visible_in(output) or window.floating) continue;
 
-            x -= self.inner_gap;
+            x -= state.scroller_inner_gap;
 
             const width: i32 = @intFromFloat(
                 @as(f32, @floatFromInt(available_width)) * window.scroller_mfact
@@ -87,7 +88,7 @@ pub fn arrange(self: *const Self, output: *Output) void {
             const window: *Window = @fieldParentPtr("link", link.next.?);
             if (!window.is_visible_in(output) or window.floating) continue;
 
-            x += self.inner_gap;
+            x += state.scroller_inner_gap;
 
             const width: i32 = @intFromFloat(
                 @as(f32, @floatFromInt(available_width)) * window.scroller_mfact

--- a/src/kwm/layout/tile.zig
+++ b/src/kwm/layout/tile.zig
@@ -25,6 +25,7 @@ pub fn arrange(self: *const Self, output: *Output) void {
     log.debug("<{*}> arrange windows in output {*}", .{ self, output });
 
     const context = Context.get();
+    const state = output.get_current_per_tag_state();
 
     var windows: std.ArrayList(*Window) = .empty;
     defer windows.deinit(utils.allocator);
@@ -45,9 +46,9 @@ pub fn arrange(self: *const Self, output: *Output) void {
     if (windows.items.len == 0) return;
 
     const usable_width, const usable_height = blk: {
-        const width = @max(0, output.exclusive_width() - 2*self.outer_gap);
-        const height = @max(0, output.exclusive_height() - 2*self.outer_gap);
-        break :blk switch (self.master_location) {
+        const width = @max(0, output.exclusive_width() - 2*state.tile_outer_gap);
+        const height = @max(0, output.exclusive_height() - 2*state.tile_outer_gap);
+        break :blk switch (state.tile_master_location) {
             .left, .right => .{ width, height },
             .top, .bottom => .{ height, width },
         };
@@ -61,10 +62,10 @@ pub fn arrange(self: *const Self, output: *Output) void {
     var stack_remain: i32 = undefined;
 
     const window_num: i32 = @intCast(windows.items.len);
-    const nmaster = @min(window_num, self.nmaster);
-    const nstack = window_num - self.nmaster;
+    const nmaster = @min(window_num, state.tile_nmaster);
+    const nstack = window_num - state.tile_nmaster;
     if (nstack > 0) {
-        master_width = @intFromFloat(self.mfact * @as(f32, @floatFromInt(usable_width)));
+        master_width = @intFromFloat(state.tile_mfact * @as(f32, @floatFromInt(usable_width)));
         master_height = @divFloor(usable_height, nmaster);
         master_remain = @mod(usable_height, nmaster);
 
@@ -84,33 +85,33 @@ pub fn arrange(self: *const Self, output: *Output) void {
         var h: i32 = undefined;
         if (i < nmaster) {
             x = 0;
-            y = (@as(i32, @intCast(i)) * master_height) + if (i > 0) master_remain + self.inner_gap else 0;
-            w = if (nstack > 0) master_width - @divFloor(self.inner_gap, 2) else master_width;
-            h = (master_height + if (i == 0) master_remain else 0) - if (i > 0) self.inner_gap else 0;
+            y = (@as(i32, @intCast(i)) * master_height) + if (i > 0) master_remain + state.tile_inner_gap else 0;
+            w = if (nstack > 0) master_width - @divFloor(state.tile_inner_gap, 2) else master_width;
+            h = (master_height + if (i == 0) master_remain else 0) - if (i > 0) state.tile_inner_gap else 0;
         } else {
-            x = master_width + @divFloor(self.inner_gap, 2);
-            y = ((@as(i32, @intCast(i))-nmaster) * stack_height) + if (i > nmaster) stack_remain + self.inner_gap else 0;
-            w = stack_width - @divFloor(self.inner_gap, 2);
-            h = (stack_height + if (i == nmaster) stack_remain else 0) - if (i > nmaster) self.inner_gap else 0;
+            x = master_width + @divFloor(state.tile_inner_gap, 2);
+            y = ((@as(i32, @intCast(i))-nmaster) * stack_height) + if (i > nmaster) stack_remain + state.tile_inner_gap else 0;
+            w = stack_width - @divFloor(state.tile_inner_gap, 2);
+            h = (stack_height + if (i == nmaster) stack_remain else 0) - if (i > nmaster) state.tile_inner_gap else 0;
         }
         w = @max(0, w);
         h = @max(0, h);
 
-        switch (self.master_location) {
+        switch (state.tile_master_location) {
             .left => {
-                window.unbound_move(x+self.outer_gap, y+self.outer_gap);
+                window.unbound_move(x+state.tile_outer_gap, y+state.tile_outer_gap);
                 window.unbound_resize(w, h);
             },
             .right => {
-                window.unbound_move(usable_width-x-w+self.outer_gap, y+self.outer_gap);
+                window.unbound_move(usable_width-x-w+state.tile_outer_gap, y+state.tile_outer_gap);
                 window.unbound_resize(w, h);
             },
             .top => {
-                window.unbound_move(y+self.outer_gap, x+self.outer_gap);
+                window.unbound_move(y+state.tile_outer_gap, x+state.tile_outer_gap);
                 window.unbound_resize(h, w);
             },
             .bottom => {
-                window.unbound_move(y+self.outer_gap, usable_width-x-w+self.outer_gap);
+                window.unbound_move(y+state.tile_outer_gap, usable_width-x-w+state.tile_outer_gap);
                 window.unbound_resize(h, w);
             }
         }

--- a/src/kwm/output.zig
+++ b/src/kwm/output.zig
@@ -29,6 +29,28 @@ pub const State = struct {
     prev_layout_tag: [32]Layout.Type,
 };
 
+pub const PerTagState = struct {
+    tile_nmaster: i32,
+    tile_mfact: f32,
+    tile_master_location: types.LayoutMasterLocation,
+    tile_inner_gap: i32,
+    tile_outer_gap: i32,
+
+    grid_direction: Layout.Grid.Direction,
+    grid_inner_gap: i32,
+    grid_outer_gap: i32,
+
+    monocle_gap: i32,
+
+    deck_master_location: types.LayoutMasterLocation,
+    deck_inner_gap: i32,
+    deck_outer_gap: i32,
+
+    // scoller.mfact is per window
+    scroller_inner_gap: i32,
+    scroller_outer_gap: i32,
+};
+
 
 link: wl.list.Link = undefined,
 
@@ -44,6 +66,7 @@ prev_tag: u32 = 1,
 prev_main_tag: u32 = 1,
 layout_tag: [32]Layout.Type,
 prev_layout_tag: [32]Layout.Type,
+per_tag_state: [32]PerTagState,
 
 name: ?[]const u8 = null,
 x: i32 = undefined,
@@ -72,6 +95,28 @@ pub fn create(
         .layout = config.layout,
         .layout_tag = .{ config.default_layout } ** 32,
         .prev_layout_tag = .{ config.default_layout } ** 32,
+        .per_tag_state = blk: {
+            var arr: [32]PerTagState = undefined;
+            for (&arr) |*v| {
+                v.* = .{
+                    .tile_nmaster = config.layout.tile.nmaster,
+                    .tile_mfact = config.layout.tile.mfact,
+                    .tile_master_location = config.layout.tile.master_location,
+                    .tile_inner_gap = config.layout.tile.inner_gap,
+                    .tile_outer_gap = config.layout.tile.outer_gap,
+                    .grid_direction = config.layout.grid.direction,
+                    .grid_inner_gap = config.layout.grid.inner_gap,
+                    .grid_outer_gap = config.layout.grid.outer_gap,
+                    .monocle_gap = config.layout.monocle.gap,
+                    .deck_master_location = config.layout.deck.master_location,
+                    .deck_inner_gap = config.layout.deck.inner_gap,
+                    .deck_outer_gap = config.layout.deck.outer_gap,
+                    .scroller_inner_gap = config.layout.scroller.inner_gap,
+                    .scroller_outer_gap = config.layout.scroller.outer_gap,
+                };
+            }
+            break :blk arr;
+        },
     };
     output.link.init();
 
@@ -239,6 +284,24 @@ pub fn set_tag(self: *Self, tag: u32) void {
 
     log.debug("<{*}> set tag: {b}", .{ self, tag });
 
+    const old_index = @ctz(self.main_tag);
+    self.per_tag_state[old_index] = .{
+        .tile_nmaster = self.layout.tile.nmaster,
+        .tile_mfact = self.layout.tile.mfact,
+        .tile_master_location = self.layout.tile.master_location,
+        .tile_inner_gap = self.layout.tile.inner_gap,
+        .tile_outer_gap = self.layout.tile.outer_gap,
+        .grid_direction = self.layout.grid.direction,
+        .grid_inner_gap = self.layout.grid.inner_gap,
+        .grid_outer_gap = self.layout.grid.outer_gap,
+        .monocle_gap = self.layout.monocle.gap,
+        .deck_master_location = self.layout.deck.master_location,
+        .deck_inner_gap = self.layout.deck.inner_gap,
+        .deck_outer_gap = self.layout.deck.outer_gap,
+        .scroller_inner_gap = self.layout.scroller.inner_gap,
+        .scroller_outer_gap = self.layout.scroller.outer_gap,
+    };
+
     self.prev_tag = self.tag;
     self.prev_main_tag = self.main_tag;
 
@@ -248,6 +311,23 @@ pub fn set_tag(self: *Self, tag: u32) void {
         self.main_tag = tag ^ (tag & (tag-1));
 
         log.debug("<{*}> update main tag to {b}", .{ self, self.main_tag });
+
+        const new_index = @ctz(self.main_tag);
+        const state = &self.per_tag_state[new_index];
+        self.layout.tile.nmaster = state.tile_nmaster;
+        self.layout.tile.mfact = state.tile_mfact;
+        self.layout.tile.master_location = state.tile_master_location;
+        self.layout.tile.inner_gap = state.tile_inner_gap;
+        self.layout.tile.outer_gap = state.tile_outer_gap;
+        self.layout.grid.direction = state.grid_direction;
+        self.layout.grid.inner_gap = state.grid_inner_gap;
+        self.layout.grid.outer_gap = state.grid_outer_gap;
+        self.layout.monocle.gap = state.monocle_gap;
+        self.layout.deck.master_location = state.deck_master_location;
+        self.layout.deck.inner_gap = state.deck_inner_gap;
+        self.layout.deck.outer_gap = state.deck_outer_gap;
+        self.layout.scroller.inner_gap = state.scroller_inner_gap;
+        self.layout.scroller.outer_gap = state.scroller_outer_gap;
     }
 
     if (comptime build_options.bar_enabled) self.bar.damage(.tags);
@@ -329,6 +409,12 @@ pub fn manage(self: *Self) void {
     self.layout.arrange(self.current_layout(), self);
 
     log.debug("<{*}> managed", .{ self });
+}
+
+
+pub fn get_current_per_tag_state(self: *Self) *PerTagState {
+    const i = @ctz(self.main_tag);
+    return &self.per_tag_state[i];
 }
 
 

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -706,9 +706,16 @@ fn handle_actions(self: *Self) void {
             .modify_nmaster => |data| {
                 if (context.current_output) |output| {
                     if (output.current_layout() == .tile) {
+                        const state = output.get_current_per_tag_state();
                         switch (data.change) {
-                            .increase => output.layout.tile.nmaster += 1,
-                            .decrease => output.layout.tile.nmaster = @max(1, output.layout.tile.nmaster-1),
+                            .increase => {
+                                state.tile_nmaster += 1;
+                                output.layout.tile.nmaster = state.tile_nmaster;
+                            },
+                            .decrease => {
+                                state.tile_nmaster = @max(1, state.tile_nmaster - 1);
+                                output.layout.tile.nmaster = state.tile_nmaster;
+                            },
                         }
                     }
                 }
@@ -717,11 +724,13 @@ fn handle_actions(self: *Self) void {
                 if (context.current_output) |output| {
                     switch (output.current_layout()) {
                         .tile => {
+                            const state = output.get_current_per_tag_state();
                             const val = switch (data.change) {
                                 .set => |set| set,
-                                .step => |step| output.layout.tile.mfact + step,
+                                .step => |step| state.tile_mfact + step,
                             };
-                            output.layout.tile.mfact = @min(1, @max(0, val));
+                            state.tile_mfact = @min(1, @max(0, val));
+                            output.layout.tile.mfact = state.tile_mfact;
                         },
                         .scroller => {
                             if (context.focus_top_in(output, false)) |window| {
@@ -738,22 +747,45 @@ fn handle_actions(self: *Self) void {
             },
             .modify_gap => |data| {
                 if (context.current_output) |output| {
+                    const state = output.get_current_per_tag_state();
                     switch (output.current_layout()) {
-                        .tile => output.layout.tile.inner_gap = @max(config.border.width*2, output.layout.tile.inner_gap+data.step),
-                        .grid => output.layout.grid.inner_gap = @max(config.border.width*2, output.layout.grid.inner_gap+data.step),
-                        .monocle => output.layout.monocle.gap = @max(config.border.width*2, output.layout.monocle.gap+data.step),
-                        .deck => output.layout.deck.inner_gap = @max(config.border.width*2, output.layout.deck.inner_gap+data.step),
-                        .scroller => output.layout.scroller.inner_gap = @max(config.border.width*2, output.layout.scroller.inner_gap+data.step),
+                        .tile => {
+                            state.tile_inner_gap = @max(config.border.width*2, state.tile_inner_gap + data.step);
+                            output.layout.tile.inner_gap = state.tile_inner_gap;
+                        },
+                        .grid => {
+                            state.grid_inner_gap = @max(config.border.width*2, state.grid_inner_gap + data.step);
+                            output.layout.grid.inner_gap = state.grid_inner_gap;
+                        },
+                        .monocle => {
+                            state.monocle_gap = @max(config.border.width*2, state.monocle_gap + data.step);
+                            output.layout.monocle.gap = state.monocle_gap;
+                        },
+                        .deck => {
+                            state.deck_inner_gap = @max(config.border.width*2, state.deck_inner_gap + data.step);
+                            output.layout.deck.inner_gap = state.deck_inner_gap;
+                        },
+                        .scroller => {
+                            state.scroller_inner_gap = @max(config.border.width*2, state.scroller_inner_gap + data.step);
+                            output.layout.scroller.inner_gap = state.scroller_inner_gap;
+                        },
                         .float => {},
                     }
                 }
             },
             .modify_master_location => |data| {
-                if (context.current_output) |output| blk: {
+                if (context.current_output) |output| {
+                    const state = output.get_current_per_tag_state();
                     switch (output.current_layout()) {
-                        .tile => output.layout.tile.master_location = data.location,
-                        .deck => output.layout.deck.master_location = data.location,
-                        else => break :blk,
+                        .tile => {
+                            state.tile_master_location = data.location;
+                            output.layout.tile.master_location = state.tile_master_location;
+                        },
+                        .deck => {
+                            state.deck_master_location = data.location;
+                            output.layout.deck.master_location = state.deck_master_location;
+                        },
+                        else => {},
                     }
                     if (comptime build_options.bar_enabled) {
                         output.bar.damage(.layout);
@@ -763,10 +795,12 @@ fn handle_actions(self: *Self) void {
             .toggle_grid_direction => {
                 if (context.current_output) |output| {
                     if (output.current_layout() == .grid) {
-                        output.layout.grid.direction = switch (output.layout.grid.direction) {
+                        const state = output.get_current_per_tag_state();
+                        state.grid_direction = switch (state.grid_direction) {
                             .horizontal => .vertical,
                             .vertical => .horizontal,
                         };
+                        output.layout.grid.direction = state.grid_direction;
                         if (comptime build_options.bar_enabled) {
                             output.bar.damage(.layout);
                         }


### PR DESCRIPTION
Currently layout states like `mfact`, `nmaster`, `gaps`, etc, are per layout.

This makes kwm behave like dwm/dwl with pertag patch.
