### PR TITLE
Feat: optimize warp cursor behavior

### DIFF
--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -174,7 +174,7 @@ pub fn manage(self: *Self) void {
         defer self.window_below_pointer.new = false;
 
         const window = self.window_below_pointer.window.?;
-        // avoid cursor wrapping
+        // avoid cursor warpping
         self.previous_focused = .{ .window = window };
 
         context.focus(
@@ -245,7 +245,7 @@ pub fn try_focus(self: *Self) void {
                 }
 
                 if (window.output) |output| {
-                    self.wrap_cursor(.{ .output = output });
+                    self.warp_cursor(.{ .output = output });
                 }
             },
             .on_focus_changed => blk: {
@@ -254,7 +254,7 @@ pub fn try_focus(self: *Self) void {
                     .window => |w| if (w == window) break :blk,
                 }
 
-                self.wrap_cursor(.{ .window = window });
+                self.warp_cursor(.{ .window = window });
             }
         }
 
@@ -277,7 +277,7 @@ pub fn try_focus(self: *Self) void {
                     .output => |o| if (o == output) break :blk,
                 }
 
-                self.wrap_cursor(.{ .output = output });
+                self.warp_cursor(.{ .output = output });
             }
         } else {
             self.previous_focused = .none;
@@ -437,10 +437,10 @@ pub fn clear_bindings(self: *Self) void {
 }
 
 
-fn wrap_cursor(self: *Self, dest: union(enum) { window: *Window, output: *Output }) void {
+fn warp_cursor(self: *Self, dest: union(enum) { window: *Window, output: *Output }) void {
     switch (dest) {
-        .window => |window| log.debug("<{*}> wrap cursor to {*}", .{ self, window }),
-        .output => |output| log.debug("<{*}> wrap cursor to {*}", .{ self, output }),
+        .window => |window| log.debug("<{*}> warp cursor to {*}", .{ self, window }),
+        .output => |output| log.debug("<{*}> warp cursor to {*}", .{ self, output }),
     }
 
     const x, const y = switch (dest) {
@@ -796,7 +796,7 @@ fn window_interaction(self: *Self, window: *Window) void {
 
     const context = Context.get();
 
-    // avoid cursor wrapping
+    // avoid cursor warpping
     self.previous_focused = .{ .window = window };
 
     context.focus(window, true);
@@ -904,7 +904,7 @@ fn rwm_seat_listener(rwm_seat: *river.SeatV1, event: river.SeatV1.Event, seat: *
                 .bar => |bar| if (comptime build_options.bar_enabled) {
                     log.debug("<{*}> interaction with {*}", .{ seat, bar });
 
-                    // avoid cursor wrapping
+                    // avoid cursor warpping
                     seat.previous_focused = .{ .output = bar.output };
 
                     context.set_current_output(bar.output);
@@ -914,7 +914,7 @@ fn rwm_seat_listener(rwm_seat: *river.SeatV1, event: river.SeatV1.Event, seat: *
                 .background => |background| if (comptime build_options.background_enabled) {
                     log.debug("<{*}> interaction with {*}", .{ seat, background });
 
-                    // avoid cursor wrapping
+                    // avoid cursor warpping
                     seat.previous_focused = .{ .output = background.output };
 
                     context.set_current_output(background.output);

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -448,10 +448,19 @@ fn warp_cursor(self: *Self, dest: union(enum) { window: *Window, output: *Output
             if (window.output) |output| {
                 const x = window.x + @divFloor(window.width, 2);
                 const y = window.y + @divFloor(window.height, 2);
-                break :blk .{
-                    output.exclusive_x() + @max(0, @min(output.exclusive_width(), x)),
-                    output.exclusive_y() + @max(0, @min(output.exclusive_height(), y)),
-                };
+                const abs_x = output.exclusive_x() + @max(0, @min(output.exclusive_width(), x));
+                const abs_y = output.exclusive_y() + @max(0, @min(output.exclusive_height(), y));
+                const pointer_x = self.pointer_position.x;
+                const pointer_y = self.pointer_position.y;
+                // if pointer already within the window, skip
+                if (
+                    @abs(pointer_x - abs_x) < @divFloor(window.width, 2)
+                    and
+                    @abs(pointer_y - abs_y) < @divFloor(window.height, 2)
+                ) {
+                    return;
+                }
+                break :blk .{ abs_x, abs_y };
             } else return;
         },
         .output => |output| .{

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -63,6 +63,7 @@ window_below_pointer: struct {
     window: ?*Window = null,
     new: bool = false,
 } = .{},
+has_pointer_interaction: bool = false,
 unhandled_actions: std.ArrayList(binding.Action) = undefined,
 xkb_bindings: std.StringHashMap(std.ArrayList(*binding.XkbBinding)) = undefined,
 pointer_bindings: std.StringHashMap(std.ArrayList(*binding.PointerBinding)) = undefined,
@@ -227,6 +228,8 @@ pub fn try_focus(self: *Self) void {
 
     if (self.focus_exclusive) return;
 
+    defer self.has_pointer_interaction = false;
+
     const config = Config.get();
     const context = Context.get();
 
@@ -235,7 +238,7 @@ pub fn try_focus(self: *Self) void {
 
         defer self.previous_focused = .{ .window = window };
 
-        switch (config.cursor_warp) {
+        if (!self.has_pointer_interaction) switch (config.cursor_warp) {
             .none => {},
             .on_output_changed => blk: {
                 switch (self.previous_focused) {
@@ -256,7 +259,7 @@ pub fn try_focus(self: *Self) void {
 
                 self.warp_cursor(.{ .window = window });
             }
-        }
+        };
 
         // if there are any window fullscreen on output, focus it first
         self.rwm_seat.focusWindow((
@@ -270,7 +273,7 @@ pub fn try_focus(self: *Self) void {
         if (context.current_output) |output| {
             defer self.previous_focused = .{ .output = output };
 
-            if (config.cursor_warp != .none) blk: {
+            if (!self.has_pointer_interaction and config.cursor_warp != .none) blk: {
                 switch (self.previous_focused) {
                     .none => {},
                     .window => |w| if (w.output == output) break :blk,
@@ -805,10 +808,8 @@ fn window_interaction(self: *Self, window: *Window) void {
 
     const context = Context.get();
 
-    // avoid cursor warpping
-    self.previous_focused = .{ .window = window };
-
     context.focus(window, true);
+    self.has_pointer_interaction = true;
 }
 
 
@@ -832,6 +833,8 @@ fn shell_surface_interaction(self: *Self, shell_surface: *ShellSurface) void {
             context.set_current_output(background.output);
         } else unreachable,
     }
+
+    self.has_pointer_interaction = true;
 }
 
 

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -812,6 +812,29 @@ fn window_interaction(self: *Self, window: *Window) void {
 }
 
 
+fn shell_surface_interaction(self: *Self, shell_surface: *ShellSurface) void {
+    log.debug("<{*}> interaction with shell surface: {*}", .{ self, shell_surface });
+
+    const context = Context.get();
+
+    switch (shell_surface.type) {
+        .layer_marker => unreachable,
+        .bar => |bar| if (comptime build_options.bar_enabled) {
+            log.debug("<{*}> interaction with {*}", .{ self, bar });
+
+            context.set_current_output(bar.output);
+
+            bar.handle_click(self);
+        } else unreachable,
+        .background => |background| if (comptime build_options.background_enabled) {
+            log.debug("<{*}> interaction with {*}", .{ self, background });
+
+            context.set_current_output(background.output);
+        } else unreachable,
+    }
+}
+
+
 fn rwm_seat_listener(rwm_seat: *river.SeatV1, event: river.SeatV1.Event, seat: *Self) void {
     std.debug.assert(rwm_seat == seat.rwm_seat);
 
@@ -906,29 +929,8 @@ fn rwm_seat_listener(rwm_seat: *river.SeatV1, event: river.SeatV1.Event, seat: *
                 @alignCast((data.shell_surface orelse return).getUserData())
             );
 
-            log.debug("<{*}> interaction with {*}", .{ seat, shell_surface });
+            seat.shell_surface_interaction(shell_surface);
 
-            switch (shell_surface.type) {
-                .layer_marker => unreachable,
-                .bar => |bar| if (comptime build_options.bar_enabled) {
-                    log.debug("<{*}> interaction with {*}", .{ seat, bar });
-
-                    // avoid cursor warpping
-                    seat.previous_focused = .{ .output = bar.output };
-
-                    context.set_current_output(bar.output);
-
-                    bar.handle_click(seat);
-                } else unreachable,
-                .background => |background| if (comptime build_options.background_enabled) {
-                    log.debug("<{*}> interaction with {*}", .{ seat, background });
-
-                    // avoid cursor warpping
-                    seat.previous_focused = .{ .output = background.output };
-
-                    context.set_current_output(background.output);
-                } else unreachable,
-            }
         },
         .window_interaction => |data| {
             log.debug("<{*}> window interaction: {*}", .{ seat, data.window });

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -175,8 +175,6 @@ pub fn manage(self: *Self) void {
         defer self.window_below_pointer.new = false;
 
         const window = self.window_below_pointer.window.?;
-        // avoid cursor warpping
-        self.previous_focused = .{ .window = window };
 
         context.focus(
             window,


### PR DESCRIPTION
closes #198 

changes:
- do not warp cursor if the pointer already within the window
- do not warp cursor if has any pointer interaction