### PR TITLE
fix(window): clamp proposed dimensions to minimum constraints

### DIFF
--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -774,6 +774,10 @@ pub fn manage(self: *Self) void {
             width -= 2 * config.border.width;
         }
 
+        // river-window-management-v1 doesn't allow negtive value
+        width = @max(width, self.min_width);
+        height = @max(height, self.min_height);
+
         break :blk .{ width, height };
     };
 


### PR DESCRIPTION
If a software sends negative dimensions, River would reject the invalid dimensions with a protocol error and cause kwm to crash.

Solves https://github.com/kewuaa/kwm/issues/218.