### PR TITLE
fix: check dimension rules before setting geometry undefined

### DIFF
--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -590,7 +590,14 @@ pub fn handle_events(self: *Self) void {
                 }
 
                 if (self.floating or self.output == null or self.output.?.current_layout() == .float) {
-                    self.geometry_undefined = true;
+                    if (self.width > 0 and self.height > 0) {
+                        self.geometry_undefined = false;
+                        if (self.output != null) {
+                            self.center();
+                        }
+                    } else {
+                        self.geometry_undefined = true;
+                    }
                 }
 
                 if (self.is_terminal) {


### PR DESCRIPTION
This fixes the regression introduced by commit
b8180cc88d3e4c20635607d7ee290c0ea267b30b where windows dimensions from rules are not respected.