### PR TITLE
feat: add centered master layout

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -94,6 +94,10 @@
                     .bottom = "[{{D}}_]",
                 },
                 .scroller = "[==]",
+                .centered_master = .{
+                    .horizontal = "=[]=",
+                    .vertical = "=[V]="
+                },
                 .float = "><>",
             },
 
@@ -180,6 +184,7 @@
         .monocle = .top,
         .deck = .stack_top,
         .scroller = .below_focused,
+        .centered_master = .top,
         .float = .top,
     },
 
@@ -202,6 +207,7 @@
     // .monocle
     // .deck
     // .scroller
+    // .centered_master
     // .float
     .default_layout = .tile,
     .layout = .{
@@ -244,6 +250,16 @@
             .mfact = 0.5,
             .inner_gap = 16,
             .outer_gap = 9,
+        },
+        .centered_master = .{
+            .nmaster = 1,
+            .mfact = 0.55,
+            .inner_gap = 12,
+            .outer_gap = 9,
+
+            // .horizontal
+            // .vertical
+            .direction = .horizontal,
         },
     },
 
@@ -767,6 +783,17 @@
                 },
             },
             .{
+                .keysym = "u",
+                .modifiers = .{ .mod4 = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .{
+                            .switch_layout = .{ .layout = .centered_master },
+                        },
+                    },
+                },
+            },
+            .{
                 .keysym = "Tab",
                 .modifiers = .{ .mod4 = true },
                 .event = .{
@@ -987,6 +1014,15 @@
                 .event = .{
                     .click = .{
                         .pressed = .toggle_grid_direction,
+                    },
+                },
+            },
+            .{
+                .keysym = "u",
+                .modifiers = .{ .mod4 = true, .shift = true },
+                .event = .{
+                    .click = .{
+                        .pressed = .toggle_centered_master_direction,
                     },
                 },
             },

--- a/src/config/bar.zig
+++ b/src/config/bar.zig
@@ -66,6 +66,7 @@ layout: ?struct {
         monocle: []const u8,
         deck: meta.enum_struct(kwm.Layout.Deck.MasterLocation, []const u8),
         scroller: []const u8,
+        centered_master: meta.enum_struct(kwm.Layout.CenteredMaster.Direction, []const u8),
         float: []const u8,
     },
     click: meta.enum_struct(

--- a/src/kwm/bar.zig
+++ b/src/kwm/bar.zig
@@ -519,6 +519,7 @@ fn render_dynamic_component(self: *Self) void {
                 .monocle => area.tags.monocle,
                 .deck => |deck| area.tags.deck.getter.get(deck.master_location),
                 .scroller => area.tags.scroller,
+                .centered_master => |centered_master| area.tags.centered_master.getter.get(centered_master.direction),
                 .float => area.tags.float,
             };
             const left = mem.indexOf(u8, tag, "{{") orelse break :blk tag;

--- a/src/kwm/binding.zig
+++ b/src/kwm/binding.zig
@@ -133,6 +133,7 @@ pub const Action = union(enum) {
     modify_gap: struct { step: i32 },
     modify_master_location: struct { location: types.LayoutMasterLocation },
     toggle_grid_direction,
+    toggle_centered_master_direction,
     toggle_auto_swallow,
 
     reload_config,

--- a/src/kwm/layout.zig
+++ b/src/kwm/layout.zig
@@ -6,6 +6,7 @@ pub const Type = enum {
     monocle,
     deck,
     scroller,
+    centered_master,
     float,
 };
 
@@ -14,6 +15,7 @@ pub const Grid = @import("layout/grid.zig");
 pub const Monocle = @import("layout/monocle.zig");
 pub const Deck = @import("layout/deck.zig");
 pub const Scroller = @import("layout/scroller.zig");
+pub const CenteredMaster = @import("layout/centered_master.zig");
 
 
 tile: Tile,
@@ -21,3 +23,4 @@ grid: Grid,
 monocle: Monocle,
 deck: Deck,
 scroller: Scroller,
+centered_master: CenteredMaster,

--- a/src/kwm/layout/centered_master.zig
+++ b/src/kwm/layout/centered_master.zig
@@ -1,0 +1,139 @@
+const Self = @This();
+
+const std = @import("std");
+const log = std.log.scoped(.centered_master);
+
+const config = @import("config");
+
+const types = @import("../types.zig");
+const Context = @import("../context.zig");
+const Output = @import("../output.zig");
+const Window = @import("../window.zig");
+
+pub const Direction = enum {
+    horizontal,
+    vertical,
+};
+
+const ctx = Context.get();
+
+nmaster: i32,
+mfact: f32,
+inner_gap: i32,
+outer_gap: i32,
+direction: Direction,
+
+
+pub fn arrange(self: *const Self, output: *Output) !void {
+    log.debug("<{*}> arrange windows in output {*}", .{ self, output });
+
+    const context = Context.get();
+
+    var windows: std.ArrayList(*Window) = .empty;
+    defer windows.deinit(ctx.gpa);
+    {
+        var it = context.windows.safeIterator(.forward);
+        while (it.next()) |window| {
+            if (
+                !window.is_visible_in(output)
+                or window.floating
+            ) continue;
+            try windows.append(ctx.gpa, window);
+        }
+    }
+
+    if (windows.items.len == 0) return;
+
+    const usable_width, const usable_height = blk: {
+        const width = @max(0, output.exclusive_width() - 2*self.outer_gap);
+        const height = @max(0, output.exclusive_height() - 2*self.outer_gap);
+        break :blk switch (self.direction) {
+            .horizontal => .{ width, height },
+            .vertical => .{ height, width },
+        };
+    };
+
+    const window_num: i32 = @intCast(windows.items.len);
+    const nmaster = @min(window_num, self.nmaster);
+    const nstack = window_num - self.nmaster;
+    const n_left_stack: i32 = if (nstack <= 0) 0 else if (nstack == 1) 1 else @divFloor(nstack, 2);
+    const n_right_stack: i32 = if (nstack <= 0) 0 else nstack - n_left_stack;
+
+    const half_gap = @divFloor(self.inner_gap, 2);
+
+    var master_width: i32 = undefined;
+    var master_height: i32 = undefined;
+    var master_remain: i32 = undefined;
+    var left_stack_width: i32 = undefined;
+    var left_height: i32 = undefined;
+    var left_remain: i32 = undefined;
+    var right_stack_width: i32 = undefined;
+    var right_height: i32 = undefined;
+    var right_remain: i32 = undefined;
+
+    if (nstack > 0) {
+        master_width = @intFromFloat(self.mfact * @as(f32, @floatFromInt(usable_width)));
+        const remaining = usable_width - master_width;
+        left_stack_width = if (n_left_stack > 0) @divFloor(remaining, 2) else 0;
+        right_stack_width = if (n_right_stack > 0) remaining - left_stack_width else 0;
+        master_width = usable_width - left_stack_width - right_stack_width;
+    } else {
+        master_width = usable_width;
+        left_stack_width = 0;
+        right_stack_width = 0;
+    }
+
+    master_height = @divFloor(usable_height, nmaster);
+    master_remain = @mod(usable_height, nmaster);
+
+    if (n_left_stack > 0) {
+        left_height = @divFloor(usable_height, n_left_stack);
+        left_remain = @mod(usable_height, n_left_stack);
+    }
+
+    if (n_right_stack > 0) {
+        right_height = @divFloor(usable_height, n_right_stack);
+        right_remain = @mod(usable_height, n_right_stack);
+    }
+
+    for (0.., windows.items) |i, window| {
+        const idx: i32 = @intCast(i);
+        var x: i32 = undefined;
+        var y: i32 = undefined;
+        var w: i32 = undefined;
+        var h: i32 = undefined;
+
+        if (i < nmaster) {
+            x = left_stack_width + (if (n_left_stack > 0) half_gap else 0);
+            y = (idx * master_height) + if (i > 0) master_remain + self.inner_gap else 0;
+            w = master_width - (if (n_left_stack > 0) half_gap else 0) - (if (n_right_stack > 0) half_gap else 0);
+            h = (master_height + if (i == 0) master_remain else 0) - if (i > 0) self.inner_gap else 0;
+        } else if (i < nmaster + n_right_stack) {
+            const ri = idx - nmaster;
+            x = left_stack_width + master_width + half_gap;
+            y = (ri * right_height) + if (ri > 0) right_remain + self.inner_gap else 0;
+            w = right_stack_width - half_gap;
+            h = (right_height + if (ri == 0) right_remain else 0) - if (ri > 0) self.inner_gap else 0;
+        } else {
+            const li = idx - nmaster - n_right_stack;
+            x = 0;
+            y = (li * left_height) + if (li > 0) left_remain + self.inner_gap else 0;
+            w = left_stack_width - half_gap;
+            h = (left_height + if (li == 0) left_remain else 0) - if (li > 0) self.inner_gap else 0;
+        }
+
+        w = @max(0, w);
+        h = @max(0, h);
+
+        switch (self.direction) {
+            .horizontal => {
+                window.unbound_move(x + self.outer_gap, y + self.outer_gap);
+                window.unbound_resize(w, h);
+            },
+            .vertical => {
+                window.unbound_move(y + self.outer_gap, x + self.outer_gap);
+                window.unbound_resize(h, w);
+            },
+        }
+    }
+}

--- a/src/kwm/output.zig
+++ b/src/kwm/output.zig
@@ -290,6 +290,7 @@ pub fn current_layout(self: *Self) union(Layout.Type) {
     monocle: *Layout.Monocle,
     deck: *Layout.Deck,
     scroller: *Layout.Scroller,
+    centered_master: *Layout.CenteredMaster,
     float,
 } {
     std.debug.assert(self.main_tag != 0 and self.main_tag & (self.main_tag-1) == 0);

--- a/src/kwm/seat.zig
+++ b/src/kwm/seat.zig
@@ -748,6 +748,10 @@ fn handle_actions(self: *Self) void {
                             .increase => deck.nmaster += 1,
                             .decrease => deck.nmaster = @max(1, deck.nmaster-1),
                         },
+                        .centered_master => |centered_master| switch (data.change) {
+                            .increase => centered_master.nmaster += 1,
+                            .decrease => centered_master.nmaster = @max(1, centered_master.nmaster-1),
+                        },
                         else => {}
                     }
                 }
@@ -778,6 +782,13 @@ fn handle_actions(self: *Self) void {
                                 window.scroller_mfact = @min(1, @max(0, mfact));
                             }
                         },
+                        .centered_master => |centered_master| {
+                            const mfact = switch (data.change) {
+                                .set => |mfact| mfact,
+                                .step => |step| centered_master.mfact + step,
+                            };
+                            centered_master.mfact = @min(1, @max(0, mfact));
+                        },
                         else => {},
                     }
                 }
@@ -790,6 +801,7 @@ fn handle_actions(self: *Self) void {
                         .monocle => |monocle| monocle.gap = @max(ctx.cfg.border.width*2, monocle.gap+data.step),
                         .deck => |deck| deck.inner_gap = @max(ctx.cfg.border.width*2, deck.inner_gap+data.step),
                         .scroller => |scroller| scroller.inner_gap = @max(ctx.cfg.border.width*2, scroller.inner_gap+data.step),
+                        .centered_master => |centered_master| centered_master.inner_gap = @max(ctx.cfg.border.width*2, centered_master.inner_gap+data.step),
                         .float => {},
                     }
                 }
@@ -811,6 +823,22 @@ fn handle_actions(self: *Self) void {
                     switch (output.current_layout()) {
                         .grid => |grid| {
                             grid.direction = switch (grid.direction) {
+                                .horizontal => .vertical,
+                                .vertical => .horizontal,
+                            };
+                            if (comptime build_options.bar_enabled) {
+                                output.bar.damage(.layout);
+                            }
+                        },
+                        else => {}
+                    }
+                }
+            },
+            .toggle_centered_master_direction => {
+                if (ctx.current_output) |output| {
+                    switch (output.current_layout()) {
+                        .centered_master => |centered_master| {
+                            centered_master.direction = switch (centered_master.direction) {
                                 .horizontal => .vertical,
                                 .vertical => .horizontal,
                             };


### PR DESCRIPTION
Adds a centered master layout with support for multiple masters and vertical direction.
```
Horizontal (=[]=)               Vertical (=[V]=)
+-----+-----------+-----+       +-----------+-----------+
|  5  |           |  2  |       |     5     |     6     |
|     |           +-----+       +-----------+-----------+
+-----+     1     |  3  |       |           1           |
|  6  |           +-----+       +-----------+-----------+
|     |           |  4  |       |   2   |   3   |   4   |
+-----+-----------+-----+       +-----------+-----------+

nmaster = 2
+-----+-----------+-----+       +-----------+-----------+
|  6  |     1     |  3  |       |     6     |     7     |
|     |           +-----+       +-----------+-----------+
+-----+-----------+  4  |       |     1     |     2     |
|  7  |     2     +-----+       +-----------+-----------+
|     |           |  5  |       |   3   |   4   |   5   |
+-----+-----------+-----+       +-----------+-----------+
```
Default keybinds: Super+u (layout), Super+Shift+u (toggle direction). Super+u matches the default in the centered master patch for DWM. Super+c would be more in line with the other layouts but collides with Super+Shift+c (close).

Not sure if the layout symbol is good.