### PR TITLE
config: fix invalid DRAG_LOCK_STATE in input rules

### DIFF
--- a/config.def.zon
+++ b/config.def.zon
@@ -1127,7 +1127,10 @@
     //          .disabled_on_external_mouse
     //      tap: .enabled or .disabled
     //      drag: .enabled or .disabled
-    //      drag_lock: .enabled or .disabled
+    //      drag_lock:
+    //          .disabled
+    //          .enabled_timeout
+    //          .enabled_sticky
     //      tap_button_map: .lrm or .lmr
     //      three_finger_drag:
     //          .disabled


### PR DESCRIPTION
Following [kwim@8fa288b](https://github.com/kewuaa/kwim/commit/8fa288bdf8d90ed039921740dc0c2ea1d8945862).