### PR TITLE
github: remove render property from logs

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -65,6 +65,5 @@ body:
         ```
         WAYLAND_DEBUG=1 firefox 2> firefox.log
         ```
-      render: shell
     validations:
       required: false


### PR DESCRIPTION
This would leave an empty block if there's no input, or break user defined syntax.