### PR TITLE
Use LLVM compiler/linker for debug builds

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -233,6 +233,12 @@ pub fn build(b: *std.Build) void {
         exe.root_module.linkSystemLibrary("fcft", .{});
     }
 
+    // Workaround for https://codeberg.org/ziglang/zig/issues/31272
+    if (optimize == .Debug) {
+        exe.use_llvm = true;
+        exe.use_lld = true;
+    }
+
     const kwm_options = b.addOptions();
     kwm_options.addOption(bool, "background_enabled", background_enabled);
     kwm_options.addOption(bool, "bar_enabled", bar_enabled);


### PR DESCRIPTION
Zig debug builds fail on systems with very recent glibc. More info here:

  https://codeberg.org/ziglang/zig/issues/31272

Since this is likely to be an issue until at least Zig 0.17, let's work around the issue temporarily by using LLVM/LLD for such builds.

Fixes #237.