### PR TITLE
urgent windows via river activation_requested (depends on river#1492)

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -88,7 +88,7 @@ pub fn build(b: *std.Build) void {
     scanner.generate("wp_cursor_shape_manager_v1", 1);
     scanner.generate("wp_fractional_scale_manager_v1", 1);
     scanner.generate("wp_single_pixel_buffer_manager_v1", 1);
-    scanner.generate("river_window_manager_v1", 4);
+    scanner.generate("river_window_manager_v1", 6);
     scanner.generate("river_xkb_bindings_v1", 2);
     scanner.generate("river_layer_shell_v1", 1);
     if (kwim_enabled) {

--- a/protocol/river-window-management-v1.xml
+++ b/protocol/river-window-management-v1.xml
@@ -34,7 +34,7 @@
     document are to be interpreted as described in IETF RFC 2119.
   </description>
 
-  <interface name="river_window_manager_v1" version="5">
+  <interface name="river_window_manager_v1" version="6">
     <description summary="window manager global interface">
       This global interface should only be advertised to the window manager
       process. Only one window management client may be active at a time. The
@@ -246,6 +246,10 @@
         The window manager may wish to restrict which key bindings are available
         while locked or otherwise use this information.
 
+        If the session is currently locked when the river_window_manager_v1
+        object is created, the session_locked event will be sent in the first
+        manage sequence.
+
         This event will be followed by a manage_start event after all other new
         state has been sent by the server.
       </description>
@@ -319,7 +323,7 @@
     </request>
   </interface>
 
-  <interface name="river_window_v1" version="5">
+  <interface name="river_window_v1" version="6">
     <description summary="a logical window">
       This represents a logical window. For example, a window may correspond to
       an xdg_toplevel or Xwayland window.
@@ -401,8 +405,8 @@
         to 0. A value of 0 indicates that the window has no preference for that
         value.
 
-        The min_width/min_height must be strictly less than or equal to the
-        max_width/max_height.
+        If the max_width/max_height is greater than 0, the min_width/min_height
+        must be strictly less than or equal to the max_width/max_height.
 
         This event will be followed by a manage_start event after all other new
         state has been sent by the server.
@@ -931,7 +935,8 @@
       <description summary="make the window fullscreen">
         Make the window fullscreen on the given output. If multiple windows are
         fullscreen on the same output at the same time only the "top" window in
-        rendering order shall be displayed.
+        rendering order shall be displayed. If the window is already fullscreen
+        on a different output, the window is switched to the new output.
 
         All river_shell_surface_v1 objects above the top fullscreen window in
         the rendering order will continue to be rendered.
@@ -1134,6 +1139,35 @@
         state has been sent by the server.
       </description>
       <arg name="count" type="uint" summary="count of screen capture sessions"/>
+    </event>
+
+    <event name="activation_requested" since="6">
+      <description summary="window requested activation">
+        This event informs the window manager that the window has requested
+        activation, for example through the xdg-activation-v1 protocol.
+
+        The seat argument indicates the seat of the input event whose serial
+        backs the activation token, or null if the token was not created with
+        an input event serial. A null seat therefore distinguishes
+        application-initiated self-promotion from activation flowing from a
+        user action.
+
+        The token argument is the activation token string. A window manager
+        that distributes tokens itself, for example when spawning clients, can
+        use it to recognize activations it initiated.
+
+        The window manager may focus the window using a river_seat_v1 request,
+        indicate urgency to the user in some other way, or ignore this event
+        entirely. The server keeps no urgency state: multiple activation
+        requests for a window between manage sequences may be coalesced into a
+        single event.
+
+        This event will be followed by a manage_start event after all other new
+        state has been sent by the server.
+      </description>
+      <arg name="seat" type="object" interface="river_seat_v1" allow-null="true"
+        summary="seat of the backing input event, if any"/>
+      <arg name="token" type="string" summary="activation token"/>
     </event>
   </interface>
 
@@ -1806,6 +1840,10 @@
 
         If the given position is outside the bounds of all outputs, the pointer
         will be warped to the closest point inside an output instead.
+
+        If an op_start_pointer request is made during the same manage sequence
+        as a pointer_warp request, the warp is applied first by the server
+        regardless of the relative ordering of the two requests.
 
         This request modifies window management state and may only be made as
         part of a manage sequence, see the river_window_manager_v1 description.

--- a/src/config/bar.zig
+++ b/src/config/bar.zig
@@ -14,6 +14,8 @@ const Color = struct {
 const Scheme = struct {
     normal: Color,
     select: Color,
+    // null renders urgent tags in the default warning colors
+    urgent: ?Color = null,
 };
 const BarArea = union(kwm.BarArea) {
     tags,

--- a/src/kwm/bar.zig
+++ b/src/kwm/bar.zig
@@ -381,6 +381,7 @@ fn render_static_component(self: *Self) void {
     const buffer = self.next_buffer(.static, w, h) orelse return;
 
     const windows_tag: u32 = self.output.occupied_tags();
+    const urgent_tag: u32 = self.output.urgent_tags();
     const focused_window = ctx.focused_window();
 
     const scheme = ctx.cfg.bar.get_scheme(.tags);
@@ -388,6 +389,10 @@ fn render_static_component(self: *Self) void {
     const select_bg = render_.utils.color(scheme.select.bg);
     const normal_fg = render_.utils.color(scheme.normal.fg);
     const normal_bg = render_.utils.color(scheme.normal.bg);
+    // solarized yellow warning colors unless configured
+    const urgent_scheme: @TypeOf(scheme.normal) = scheme.urgent orelse .{ .fg = 0x002b36ff, .bg = 0xb58900ff };
+    const urgent_fg = render_.utils.color(urgent_scheme.fg);
+    const urgent_bg = render_.utils.color(urgent_scheme.bg);
 
     const bg_rect = [_]pixman.Rectangle16 {
         .{
@@ -405,11 +410,16 @@ fn render_static_component(self: *Self) void {
         const tag: u32 = @as(u32, @intCast(1)) << @as(u5, @intCast(i));
 
         const is_focused = self.output.tag & tag != 0;
+        // urgency outranks focus: an urgent tag stays loud until visited
+        const is_urgent = urgent_tag & tag != 0;
 
-        const tag_width: u16 = @intCast(render_.utils.text_width(text)+pad); 
+        const fg = if (is_urgent) &urgent_fg else if (is_focused) &select_fg else &normal_fg;
+        const bg = if (is_urgent) &urgent_bg else if (is_focused) &select_bg else &normal_bg;
+
+        const tag_width: u16 = @intCast(render_.utils.text_width(text)+pad);
         defer x += @intCast(tag_width);
 
-        if (is_focused) {
+        if (is_focused or is_urgent) {
             const tag_rect = [_]pixman.Rectangle16 {
                 .{
                     .x = x,
@@ -421,7 +431,7 @@ fn render_static_component(self: *Self) void {
             _ = pixman.Image.fillRectangles(
                 .src,
                 buffer.image,
-                &select_bg,
+                bg,
                 1,
                 &tag_rect,
             );
@@ -432,7 +442,7 @@ fn render_static_component(self: *Self) void {
                 buffer,
                 false,
                 .top,
-                if (is_focused) &select_fg else &normal_fg,
+                fg,
                 x,
                 y,
             );
@@ -442,7 +452,7 @@ fn render_static_component(self: *Self) void {
                     buffer,
                     true,
                     .top,
-                    if (is_focused) &select_bg else &normal_bg,
+                    bg,
                     x,
                     y,
                 );
@@ -452,7 +462,7 @@ fn render_static_component(self: *Self) void {
         _ = self.font.render_text(
             buffer,
             text,
-            if (is_focused) &select_fg else &normal_fg,
+            fg,
             x+@as(i16, @intCast(@divFloor(pad, 2))),
             y,
         );

--- a/src/kwm/context.zig
+++ b/src/kwm/context.zig
@@ -1392,13 +1392,33 @@ fn rwm_input_manager_listener(rwm_input_manager: *river.InputManagerV1, event: r
             log.debug("new input_device {*}", .{ data.id });
 
             context.trigger_hotplug();
-            data.id.destroy();
+
+            // The device object must stay alive until its removed event:
+            // river_xkb_keyboard_v1.input_device and
+            // river_libinput_device_v1.input_device reference it as their
+            // first event, and destroying it here races those in-flight
+            // events into a fatal unknown-object dispatch error.
+            data.id.setListener(*Self, rwm_input_device_listener, context);
         },
         .finished => {
             log.debug("{*} finished", .{ rwm_input_manager });
 
             rwm_input_manager.destroy();
         }
+    }
+}
+
+
+fn rwm_input_device_listener(rwm_input_device: *river.InputDeviceV1, event: river.InputDeviceV1.Event, context: *Self) void {
+    _ = context;
+
+    switch (event) {
+        .removed => {
+            log.debug("input_device {*} removed", .{ rwm_input_device });
+
+            rwm_input_device.destroy();
+        },
+        .type, .name => {}
     }
 }
 

--- a/src/kwm/context.zig
+++ b/src/kwm/context.zig
@@ -536,6 +536,7 @@ pub fn quit(self: *Self, exit_session: bool) void {
 pub fn focus(self: *Self, window: *Window, lift: bool) void {
     log.debug("<{*}> focus window: {*}", .{ self, window });
 
+    window.urgent = false;
     self.set_current_output(window.output);
     if (lift) self.window_to_lift = window;
 

--- a/src/kwm/output.zig
+++ b/src/kwm/output.zig
@@ -267,6 +267,18 @@ pub fn occupied_tags(self: *const Self) u32 {
 }
 
 
+pub fn urgent_tags(self: *const Self) u32 {
+    var mask: u32 = 0;
+    {
+        var it = ctx.windows.safeIterator(.forward);
+        while (it.next()) |window| {
+            if (window.output == self and window.urgent) mask |= window.tag;
+        }
+    }
+    return mask;
+}
+
+
 pub fn toggle_tag(self: *Self, mask: u32) void {
     if (self.tag ^ mask == 0) return;
 
@@ -379,6 +391,7 @@ fn rwm_output_listener(rwm_output: *river.OutputV1, event: river.OutputV1.Event,
     std.debug.assert(rwm_output == output.rwm_output);
 
     switch (event) {
+        .capture_sessions => {},
         .dimensions => |data| {
             log.debug("<{*}> new dimensions: (width: {}, height: {})", .{ output, data.width, data.height });
 

--- a/src/kwm/window.zig
+++ b/src/kwm/window.zig
@@ -85,6 +85,7 @@ maximize: bool = false,
 floating: bool = false,
 sticky: bool = false,
 hidden: bool = false,
+urgent: bool = false,
 clip_state: enum {
     unknow,
     normal,
@@ -1052,6 +1053,20 @@ fn rwm_window_listener(rwm_window: *river.WindowV1, event: river.WindowV1.Event,
             log.debug("<{*}> closed", .{ window });
 
             window.destroy();
+        },
+        .capture_sessions => {},
+        .activation_requested => |data| {
+            log.debug("<{*}> activation requested (seat: {?*}, token: {s})", .{ window, data.seat, data.token });
+
+            // Urgency only for now: the focused window already has the
+            // user's attention. The seat/token args allow smarter policy
+            // (focus-on-activation for launches the WM initiated) later.
+            if (window != ctx.focused_window()) {
+                window.urgent = true;
+                if (comptime build_options.bar_enabled) {
+                    if (window.output) |output| output.bar.damage(.tags);
+                }
+            }
         },
         .decoration_hint => |data| {
             log.debug("<{*}> decoration hint: {s}", .{ window, @tagName(data.hint) });

--- a/src/main.zig
+++ b/src/main.zig
@@ -163,7 +163,7 @@ fn registry_listener(registry: *wl.Registry, event: wl.Registry.Event, globals: 
             } else if (mem.orderZ(u8, global.interface, wp.SinglePixelBufferManagerV1.interface.name) == .eq) {
                 globals.wp_single_pixel_buffer_manager = registry.bind(global.name, wp.SinglePixelBufferManagerV1, 1) catch return;
             } else if (mem.orderZ(u8, global.interface, river.WindowManagerV1.interface.name) == .eq) {
-                globals.rwm = registry.bind(global.name, river.WindowManagerV1, 4) catch return;
+                globals.rwm = registry.bind(global.name, river.WindowManagerV1, @min(global.version, 6)) catch return;
             } else if (mem.orderZ(u8, global.interface, river.XkbBindingsV1.interface.name) == .eq) {
                 globals.rwm_xkb_bindings = registry.bind(global.name, river.XkbBindingsV1, 2) catch return;
             } else if (mem.orderZ(u8, global.interface, river.LayerShellV1.interface.name) == .eq) {


### PR DESCRIPTION
> **Provenance:** designed and implemented by Claude (Anthropic's AI
> assistant); reviewed by a human coder, who daily-drives the patched
> build. The commit carries a matching co-author trailer.

**Draft — depends on unreleased river protocol.** This implements
urgent windows (dwm-style flashing tags) on top of the
`river_window_v1.activation_requested` event proposed in
river PR [#1492](https://codeberg.org/river/river/pulls/1492) — see our
design comment there for the seat+token argument rationale. It cannot
work on any released river yet; parking it here as a draft for
visibility and early review.

What it does:

- Tracks per-window urgency: set on `activation_requested` when the
  window is not focused, cleared when it gains focus.
- The bar paints urgent tags in warning colors — solarized yellow by
  default, configurable as `.bar.scheme.urgent` — taking precedence
  over select/normal.
- Protocol bump 4→6 with the registry bind capped at the server's
  advertised version, so kwm keeps working unchanged against stock
  river 0.4.x (just without urgency). The v5 `capture_sessions` events
  this pulls in are acknowledged and ignored.
- The event's seat/token arguments are logged but not yet acted upon;
  they enable focus-on-activation policy as a follow-up.

Validated live against the patched river
(https://github.com/thinkoid/river/commits/activation-requested): a
GTK4 client re-presenting itself every 5s lights its tag yellow from
another tag; visiting the tag clears it.
